### PR TITLE
Address Issue #71 - Make Unit test and Integration test templates available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ Make sure to run these tests before submitting a pull request.
 I.e. you can use [MetaFixers](https://github.com/PowerShell/DscResource.Tests/blob/master/MetaFixers.psm1) to convert all indentations and file encodings.
 
 ### Test Templates
-We have provided a set of test templates for you to use to create new tests using. There is single file for unit and two for integration tests. These test templates are availabing in the [Tests.Template folder](Tests.Template).
+We have provided a set of test templates for you to use to create new tests. There is single file for unit tests and two for integration tests. These test templates are availabing in the [Tests.Template folder](Tests.Template).
 For instructions on how to use these templates, please read the [Tests Guidlines Document](TestsGuidelines.md).
 
 ### Run common tests locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,11 +144,11 @@ If none of the existing issues look related, [open a new issue](https://github.c
 
 Next, develop your DSC resources in your own module repository. Make sure you:
 
-* Write a set of test cases specific to your resources using Pester. 
-Place them in a `Tests` directory. ([See details regarding adding tests](https://github.com/PowerShell/DscResources/blob/master/CONTRIBUTING.md#adding-test-coverage-for-dsc-resources))
+* Write a set of Unit and Integration test cases specific to your resources using Pester using the test templates from the [Tests.Template folder](Tests.Template).
+Place them in `Tests\Unit` and `Tests\Integration` directories. ([See details regarding adding tests](https://github.com/PowerShell/DscResources/blob/master/CONTRIBUTING.md#adding-test-coverage-for-dsc-resources))
 * Use the template from the [DscResource.Template folder](DscResource.Template) as a boilerplate for [appveyor.yml] (https://github.com/PowerShell/DscResources/blob/master/DscResource.Template/appveyor.yml) (continuous integration configuration file) and [README.md](https://github.com/PowerShell/DscResources/blob/master/DscResource.Template/README.md).
-
-* Run all common tests located in [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) 
+* If you have used the [Tests.Template folder](Tests.Template) to create your unit and integration tests then the common tests located in [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) will be automatically installed for you when your tests are run. 
+* If you did not use the [Tests.Template folder](Tests.Template) for your unit and integration testts, run all common tests located in [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) 
 
 Follow up in the issue you opened to discuss repo ownership with the PowerShell team.
 There are two options:
@@ -189,9 +189,15 @@ Make sure to run these tests before submitting a pull request.
 [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) contains **Fixers** where it's possible.
 I.e. you can use [MetaFixers](https://github.com/PowerShell/DscResource.Tests/blob/master/MetaFixers.psm1) to convert all indentations and file encodings.
 
-### Run common tests locally
+### Test Templates
+We have provided a set of test templates for you to use to create new tests using. There is single file for unit and two for integration tests. These test templates are availabing in the [Tests.Template folder](Tests.Template).
 
-To run these common tests on your machine, you should clone [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) to resource directory that you want to test.
+For instructions on how to use these templates, please read the [Tests Guidlines Document](TestsGuidelines.md).
+
+### Run common tests locally
+If you have created your tests using the [Tests.Template](Tests.Template) files then the [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) will automatically be downloaded into the module folder when the tests are invoked.
+
+If you did not use the [Tests.Template](Tests.Template) to create your tests then you will need to run these common tests on your machine, you should clone [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) to resource directory that you want to test.
 Then run `Invoke-Pester` from root.
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,8 +147,7 @@ Next, develop your DSC resources in your own module repository. Make sure you:
 * Write a set of Unit and Integration test cases specific to your resources using Pester using the test templates from the [Tests.Template folder](Tests.Template).
 Place them in `Tests\Unit` and `Tests\Integration` directories. ([See details regarding adding tests](https://github.com/PowerShell/DscResources/blob/master/CONTRIBUTING.md#adding-test-coverage-for-dsc-resources))
 * Use the template from the [DscResource.Template folder](DscResource.Template) as a boilerplate for [appveyor.yml] (https://github.com/PowerShell/DscResources/blob/master/DscResource.Template/appveyor.yml) (continuous integration configuration file) and [README.md](https://github.com/PowerShell/DscResources/blob/master/DscResource.Template/README.md).
-* If you have used the [Tests.Template folder](Tests.Template) to create your unit and integration tests then the common tests located in [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) will be automatically installed for you when your tests are run. 
-* If you did not use the [Tests.Template folder](Tests.Template) for your unit and integration testts, run all common tests located in [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) 
+* When you run tests based on the templates the common tests located in [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) will be automatically installed into the root folder of your module when your tests are run. 
 
 Follow up in the issue you opened to discuss repo ownership with the PowerShell team.
 There are two options:
@@ -191,7 +190,6 @@ I.e. you can use [MetaFixers](https://github.com/PowerShell/DscResource.Tests/bl
 
 ### Test Templates
 We have provided a set of test templates for you to use to create new tests using. There is single file for unit and two for integration tests. These test templates are availabing in the [Tests.Template folder](Tests.Template).
-
 For instructions on how to use these templates, please read the [Tests Guidlines Document](TestsGuidelines.md).
 
 ### Run common tests locally

--- a/DscResource.Template/.gitignore
+++ b/DscResource.Template/.gitignore
@@ -1,0 +1,1 @@
+DSCResource.Tests

--- a/Tests.Template/integration_config_template.ps1
+++ b/Tests.Template/integration_config_template.ps1
@@ -1,0 +1,24 @@
+<#
+.Synopsis
+   DSC Configuration Template for DSC Resource Integration tests.
+.DESCRIPTION
+   To Use:
+     1. Copy to \Tests\Integration\ folder and rename MSFT_<ResourceName>.config.ps1 (e.g. MSFT_xFirewall.config.ps1)
+     2. Customize TODO sections.
+
+.NOTES
+#>
+
+
+# TODO: Modify ResourceName
+configuration 'MSFT_<ResourceName>_config' {
+    Import-DscResource -Name 'MSFT_<ResourceName>'
+    node localhost {
+       # TODO: Modify ResourceName
+       '<ResourceName>' Integration_Test {
+            # TODO: Fill Configuration Code Here
+       }
+    }
+}
+
+# TODO: (Optional): Add More Configuration Templates

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -1,0 +1,75 @@
+<#
+.Synopsis
+   Template for creating DSC Resource Integration Tests
+.DESCRIPTION
+   To Use:
+     1. Copy to \Tests\Integration\ folder and rename MSFT_x<ResourceName>.Integration.tests.ps1
+     2. Customize TODO sections.
+     3. Create test DSC Configurtion file MSFT_x<ResourceName>.config.ps1 from integration_config_template.ps1 file.
+
+.NOTES
+   Code in HEADER, FOOTER and DEFAULT TEST regions are standard and may be moved into
+   DSCResource.Tools in Future and therefore should not be altered if possible.
+#>
+
+# TODO: Customize these parameters...
+$Global:DSCModuleName      = 'x<ModuleName>' # Example xNetworking
+$Global:DSCResourceName    = 'MSFT_x<ResourceName>' # Example MSFT_xFirewall
+# /TODO
+
+#region HEADER
+if ( (-not (Test-Path -Path '.\DSCResource.Tests\')) -or `
+     (-not (Test-Path -Path '.\DSCResource.Tests\TestHelper.psm1')) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
+}
+else
+{
+    & git @('-C',(Join-Path -Path (Get-Location) -ChildPath '\DSCResource.Tests\'),'pull')
+}
+Import-Module .\DSCResource.Tests\TestHelper.psm1 -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Integration 
+#endregion
+
+# TODO: Other Init Code Goes Here...
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    #region Integration Tests
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    . $ConfigFile
+
+    Describe "$($Global:DSCResourceName)_Integration" {
+        #region DEFAULT TESTS
+        It 'Should compile without throwing' {
+            {
+                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder `
+                    -ComputerName localhost -Wait -Verbose -Force
+            } | Should not throw
+        }
+
+        It 'should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        }
+        #endregion
+
+        It 'Should have set the resource and all the parameters should match' {
+            # TODO: Validate the Config was Set Correctly Here...
+        }
+    }
+    #endregion
+
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+
+    # TODO: Other Optional Cleanup Code Goes Here...
+}

--- a/Tests.Template/unit_template.ps1
+++ b/Tests.Template/unit_template.ps1
@@ -1,0 +1,86 @@
+<#
+.Synopsis
+   Template for creating DSC Resource Unit Tests
+.DESCRIPTION
+   To Use:
+     1. Copy to \Tests\Integration\ folder and rename MSFT_x<ResourceName>.tests.ps1
+     2. Customize TODO sections.
+
+.NOTES
+   Code in HEADER and FOOTER regions are standard and may be moved into DSCResource.Tools in
+   Future and therefore should not be altered if possible.
+#>
+
+
+# TODO: Customize these parameters...
+$Global:DSCModuleName      = 'x<ModuleName>' # Example xNetworking
+$Global:DSCResourceName    = 'MSFT_x<ResourceName>' # Example MSFT_xFirewall
+# /TODO
+
+#region HEADER
+if ( (-not (Test-Path -Path '.\DSCResource.Tests\')) -or `
+     (-not (Test-Path -Path '.\DSCResource.Tests\TestHelper.psm1')) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
+}
+else
+{
+    & git @('-C',(Join-Path -Path (Get-Location) -ChildPath '\DSCResource.Tests\'),'pull')
+}
+Import-Module .\DSCResource.Tests\TestHelper.psm1 -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Unit 
+#endregion
+
+# TODO: Other Optional Init Code Goes Here...
+
+# Begin Testing
+try
+{
+
+    #region Pester Tests
+
+    # The InModuleScope command allows you to perform white-box unit testing on the internal
+    # (non-exported) code of a Script Module.
+    InModuleScope $Global:DSCResourceName {
+
+        #region Pester Test Initialization
+        # TODO: Optopnal Load Mock for use in Pester tests here...
+        #endregion
+
+
+        #region Function Get-TargetResource
+        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+            # TODO: Complete Tests...
+        }
+        #endregion
+
+
+        #region Function Test-TargetResource
+        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+            # TODO: Complete Tests...
+        }
+        #endregion
+
+
+        #region Function Set-TargetResource
+        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+            # TODO: Complete Tests...
+        }
+        #endregion
+
+        # TODO: Pester Tests for any Helper Cmdlets
+
+    }
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+
+    # TODO: Other Optional Cleanup Code Goes Here...
+}

--- a/Tests.Template/unit_template.ps1
+++ b/Tests.Template/unit_template.ps1
@@ -3,7 +3,7 @@
    Template for creating DSC Resource Unit Tests
 .DESCRIPTION
    To Use:
-     1. Copy to \Tests\Integration\ folder and rename MSFT_x<ResourceName>.tests.ps1
+     1. Copy to \Tests\Unit\ folder and rename MSFT_x<ResourceName>.tests.ps1
      2. Customize TODO sections.
 
 .NOTES

--- a/TestsGuidelines.md
+++ b/TestsGuidelines.md
@@ -1,0 +1,45 @@
+# DSC Resource Testing Guidelines
+
+General Rules
+-------------
+
+ * Each DSC module should contain the following Test folder structure:
+       Tests
+       |---Unit
+       |---Integration
+ * The Tests\Unit folder must contain a Test Script for each DSC Resource in the DSC Module with the filename MSFT_<ResourceName>.tests.ps1.
+ * The Tests\Integration folder should, whenever possible, contain a Test Script for each DSC Resource in the DSC Module with the filename MSFT_<ResourceName>.integration.tests.ps1.
+ * Each Test Script should contain [Pester](https://github.com/pester/Pester) based tests.
+ * Integration tests should be created when possible, but for some DSC resources this may not be possible. For example, when integration tests would cause the testing computer configuration to be damaged. 
+ * Unit and Integration tests should be created using the Template files that are located in the [Tests.Template](Tests.Template) folder in this repository.
+ * The Unit and Integration test templates require that Git.exe be installed and can be found in the %PATH% on the testing computer.
+ * The Unit and Integration test templates will automatically download or update the [DSCResource.Tests repository](https://github.com/PowerShell/DscResource.Tests) using Git.exe to the DSC Module folder.
+ * Ensure that the .gitignore file for the resource module contains **DSCResource.Tests** so that this folder is not accidentally included in a commit to your resource repository. 
+
+Creating DSC Resource Unit Test Instructions
+============================================
+ 1. Copy the \Tests.Template\unit_template.ps1 to the \Tests\Integration\ folder and rename to MSFT_x<ResourceName>.tests.ps1
+ 2. Open MSFT_x<ResourceName>.tests.ps1 and customize TODO sections.
+
+Creating DSC Resource Integration Test Instructions
+===================================================
+ 1. Copy the \Tests.Template\integration_template.ps1 to \Tests\Integration\ folder and rename MSFT_x<ResourceName>.Integration.tests.ps1
+ 2. Open MSFT_x<ResourceName>.Integration.tests.ps1 and customize TODO sections.
+ 3. Copy the \Tests.Template\integration_comfig_template.ps1 to \Tests\Integration\ folder and rename MSFT_x<ResourceName>.config.ps1 
+ 4. Open MSFT_x<ResourceName>.config.ps1 and customize TODO sections.
+ 
+Running Tests Locally
+=====================
+All tests are automatically run via AppVeyor when the repository is updated. However, it is recommended that all tests be run locally before being commited.
+
+Requirements for running all tests locally:
+1. Git is installed and the Git.exe can be found in the %PATH% variable.
+2. The latest [Pester Module](https://github.com/pester/Pester) is installed, either manually or via PowerShellGet.
+3. An internet connection is available so that the DSCResource.Tests repository can be downloaded using Git. This only needs to be done once and so is only required the first time the tests are run.
+ 
+Example Tests
+=============
+To see examples of the Unit/Integration tests in practice, see the xNetworking MSFT_xFirewall resource:
+[Unit Tests](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Unit/MSFT_xFirewall.Tests.ps1)
+[Integration Tests](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1)
+[Resource DSC Configuration](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Integration/MSFT_xFirewall.config.ps1)

--- a/TestsGuidelines.md
+++ b/TestsGuidelines.md
@@ -6,40 +6,38 @@ General Rules
  * Each DSC module should contain the following Test folder structure:
 
        Tests
-
        |---Unit
-
        |---Integration
 
- * The Tests\Unit folder must contain a Test Script for each DSC Resource in the DSC Module with the filename MSFT_<ResourceName>.tests.ps1.
- * The Tests\Integration folder should, whenever possible, contain a Test Script for each DSC Resource in the DSC Module with the filename MSFT_<ResourceName>.integration.tests.ps1.
+ * The Tests\Unit folder must contain a Test Script for each DSC Resource in the DSC Module with the filename ```MSFT_<<ResourceName>>.tests.ps1```.
+ * The Tests\Integration folder should, whenever possible, contain a Test Script for each DSC Resource in the DSC Module with the filename ```MSFT_<<ResourceName>>.integration.tests.ps1```.
  * Each Test Script should contain [Pester](https://github.com/pester/Pester) based tests.
  * Integration tests should be created when possible, but for some DSC resources this may not be possible. For example, when integration tests would cause the testing computer configuration to be damaged. 
  * Unit and Integration tests should be created using the Template files that are located in the [Tests.Template](Tests.Template) folder in this repository.
- * The Unit and Integration test templates require that Git.exe be installed and can be found in the %PATH% on the testing computer.
+ * The Unit and Integration test templates require that ```Git.exe``` be installed and can be found in the ```%PATH%``` on the testing computer.
  * The Unit and Integration test templates will automatically download or update the [DSCResource.Tests repository](https://github.com/PowerShell/DscResource.Tests) using Git.exe to the DSC Module folder.
  * Ensure that the .gitignore file for the resource module contains **DSCResource.Tests** so that this folder is not accidentally included in a commit to your resource repository. 
 
 Creating DSC Resource Unit Test Instructions
 ============================================
- 1. Copy the \Tests.Template\unit_template.ps1 to the \Tests\Integration\ folder and rename to MSFT_x<ResourceName>.tests.ps1
- 2. Open MSFT_x<ResourceName>.tests.ps1 and customize TODO sections.
+ 1. Copy the ```\Tests.Template\unit_template.ps1``` to the ```\Tests\Integration\``` folder and rename to ```MSFT_x<ResourceName>.tests.ps1```
+ 2. Open ```MSFT_x<ResourceName>.tests.ps1``` and customize TODO sections.
 
 Creating DSC Resource Integration Test Instructions
 ===================================================
- 1. Copy the \Tests.Template\integration_template.ps1 to \Tests\Integration\ folder and rename MSFT_x<ResourceName>.Integration.tests.ps1
- 2. Open MSFT_x<ResourceName>.Integration.tests.ps1 and customize TODO sections.
- 3. Copy the \Tests.Template\integration_comfig_template.ps1 to \Tests\Integration\ folder and rename MSFT_x<ResourceName>.config.ps1 
- 4. Open MSFT_x<ResourceName>.config.ps1 and customize TODO sections.
+ 1. Copy the ```\Tests.Template\integration_template.ps1``` to ```\Tests\Integration\``` folder and rename ```MSFT_x<ResourceName>.Integration.tests.ps1```
+ 2. Open ```MSFT_x<ResourceName>.Integration.tests.ps1``` and customize TODO sections.
+ 3. Copy the ```\Tests.Template\integration_comfig_template.ps1``` to ```\Tests\Integration\``` folder and rename ```MSFT_x<ResourceName>.config.ps1```
+ 4. Open ```MSFT_x<ResourceName>.config.ps1``` and customize TODO sections.
  
 Running Tests Locally
 =====================
-All tests are automatically run via AppVeyor when the repository is updated. However, it is recommended that all tests be run locally before being commited.
+All tests are automatically run via AppVeyor when the repository is updated. However, it is recommended that all tests be run locally before being committed.
 
 Requirements for running all tests locally:
- 1. Git is installed and the Git.exe can be found in the %PATH% variable.
+ 1. Git is installed and the ```Git.exe``` can be found in the ```%PATH%``` variable.
  2. The latest [Pester Module](https://github.com/pester/Pester) is installed, either manually or via PowerShellGet.
- 3. An internet connection is available so that the DSCResource.Tests repository can be downloaded using Git. This only needs to be done once and so is only required the first time the tests are run.
+ 3. An internet connection is available so that the DSCResource.Tests repository can be downloaded or updated using Git.
  
 Example Tests
 =============

--- a/TestsGuidelines.md
+++ b/TestsGuidelines.md
@@ -4,13 +4,13 @@ General Rules
 -------------
 
  * Each DSC module should contain the following Test folder structure:
-
+```
        Tests
        |---Unit
        |---Integration
-
- * The Tests\Unit folder must contain a Test Script for each DSC Resource in the DSC Module with the filename ```MSFT_<<ResourceName>>.tests.ps1```.
- * The Tests\Integration folder should, whenever possible, contain a Test Script for each DSC Resource in the DSC Module with the filename ```MSFT_<<ResourceName>>.integration.tests.ps1```.
+```
+ * The Tests\Unit folder must contain a Test Script for each DSC Resource in the DSC Module with the filename ```MSFT_<ResourceName>.tests.ps1```.
+ * The Tests\Integration folder should, whenever possible, contain a Test Script for each DSC Resource in the DSC Module with the filename ```MSFT_<ResourceName>.integration.tests.ps1```.
  * Each Test Script should contain [Pester](https://github.com/pester/Pester) based tests.
  * Integration tests should be created when possible, but for some DSC resources this may not be possible. For example, when integration tests would cause the testing computer configuration to be damaged. 
  * Unit and Integration tests should be created using the Template files that are located in the [Tests.Template](Tests.Template) folder in this repository.

--- a/TestsGuidelines.md
+++ b/TestsGuidelines.md
@@ -4,9 +4,13 @@ General Rules
 -------------
 
  * Each DSC module should contain the following Test folder structure:
+
        Tests
+
        |---Unit
+
        |---Integration
+
  * The Tests\Unit folder must contain a Test Script for each DSC Resource in the DSC Module with the filename MSFT_<ResourceName>.tests.ps1.
  * The Tests\Integration folder should, whenever possible, contain a Test Script for each DSC Resource in the DSC Module with the filename MSFT_<ResourceName>.integration.tests.ps1.
  * Each Test Script should contain [Pester](https://github.com/pester/Pester) based tests.
@@ -33,13 +37,13 @@ Running Tests Locally
 All tests are automatically run via AppVeyor when the repository is updated. However, it is recommended that all tests be run locally before being commited.
 
 Requirements for running all tests locally:
-1. Git is installed and the Git.exe can be found in the %PATH% variable.
-2. The latest [Pester Module](https://github.com/pester/Pester) is installed, either manually or via PowerShellGet.
-3. An internet connection is available so that the DSCResource.Tests repository can be downloaded using Git. This only needs to be done once and so is only required the first time the tests are run.
+ 1. Git is installed and the Git.exe can be found in the %PATH% variable.
+ 2. The latest [Pester Module](https://github.com/pester/Pester) is installed, either manually or via PowerShellGet.
+ 3. An internet connection is available so that the DSCResource.Tests repository can be downloaded using Git. This only needs to be done once and so is only required the first time the tests are run.
  
 Example Tests
 =============
 To see examples of the Unit/Integration tests in practice, see the xNetworking MSFT_xFirewall resource:
-[Unit Tests](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Unit/MSFT_xFirewall.Tests.ps1)
-[Integration Tests](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1)
-[Resource DSC Configuration](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Integration/MSFT_xFirewall.config.ps1)
+- [Unit Tests](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Unit/MSFT_xFirewall.Tests.ps1)
+- [Integration Tests](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1)
+- [Resource DSC Configuration](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Integration/MSFT_xFirewall.config.ps1)

--- a/TestsGuidelines.md
+++ b/TestsGuidelines.md
@@ -19,19 +19,19 @@ General Rules
  * Ensure that the .gitignore file for the resource module contains **DSCResource.Tests** so that this folder is not accidentally included in a commit to your resource repository. 
 
 Creating DSC Resource Unit Test Instructions
-============================================
+--------------------------------------------
  1. Copy the ```\Tests.Template\unit_template.ps1``` to the ```\Tests\Integration\``` folder and rename to ```MSFT_x<ResourceName>.tests.ps1```
  2. Open ```MSFT_x<ResourceName>.tests.ps1``` and customize TODO sections.
 
 Creating DSC Resource Integration Test Instructions
-===================================================
+---------------------------------------------------
  1. Copy the ```\Tests.Template\integration_template.ps1``` to ```\Tests\Integration\``` folder and rename ```MSFT_x<ResourceName>.Integration.tests.ps1```
  2. Open ```MSFT_x<ResourceName>.Integration.tests.ps1``` and customize TODO sections.
  3. Copy the ```\Tests.Template\integration_comfig_template.ps1``` to ```\Tests\Integration\``` folder and rename ```MSFT_x<ResourceName>.config.ps1```
  4. Open ```MSFT_x<ResourceName>.config.ps1``` and customize TODO sections.
  
 Running Tests Locally
-=====================
+---------------------
 All tests are automatically run via AppVeyor when the repository is updated. However, it is recommended that all tests be run locally before being committed.
 
 Requirements for running all tests locally:
@@ -40,7 +40,7 @@ Requirements for running all tests locally:
  3. An internet connection is available so that the DSCResource.Tests repository can be downloaded or updated using Git.
  
 Example Tests
-=============
+-------------
 To see examples of the Unit/Integration tests in practice, see the xNetworking MSFT_xFirewall resource:
 - [Unit Tests](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Unit/MSFT_xFirewall.Tests.ps1)
 - [Integration Tests](https://github.com/PowerShell/xNetworking/blob/dev/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1)


### PR DESCRIPTION
This change/addition addresses Issue #71 Add Unit and Integration Test Templates. These templates were originally created in the xNetworking DSC resource by @tysonjhayes. They have been converted over into two general purpose templates (and a support file for integration tests) so that they could be added to any DSC module.

Added files are:
- Tests.Template/integration_template.ps1 - Integration test template.
- Tests.Template/integration_config_template.ps1 - DSC config file used by the Integration test template.
- Tests.Template/unit_template.ps1 - Unit test template.
- DscResource.Template/.gitignore - this file is added to ensure that any new DSC repositories based on this resource template do not accidentally commit DSCResource.Tests into a repo by default. The new test templates will automatically download DSCResource.Tests repo to the module folder to perform tests, so ensuring it doesn't get commited back by accident should be a default behavior.
- TestsGuidelines.md - guidelines and instructions for using the unit/integration test templates.

Updated files:
- CONTRIBUTING.md - added/updated info on creating tests.

All feedback is much appreciated here, but there is no rush on this one - just thought I'd get it in there before the end of the year :+1: 

Thankyou!



