### PR TITLE
Parameter names should use PascalCase. Fixes #78

### DIFF
--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -133,6 +133,35 @@ function Get-TargetResource
 }
 ```
 
+Parameter names should use PascalCase 
+-------------------------------------------------------------
+
+**Bad:**
+```powershell
+function Get-TargetResource
+{
+    ...
+     param
+     (
+         ...
+         $SOURCEPATH
+         ...
+}
+```
+
+**Good:**
+```powershell
+function Get-TargetResource
+{
+    [CmdletBinding()]
+     param
+     (
+         ...
+         $SourcePath
+         ...
+}
+```
+
 Variable names should use camelCase
 -------------------------------------------------------------
 


### PR DESCRIPTION
Add style guidleline to use Pascal Casing when naming Parameters.