### PR TITLE
Allow tests to be Invoked when current folder is not Module Root. Fixes #24

### DIFF
--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -17,17 +17,18 @@ $Global:DSCModuleName      = 'x<ModuleName>' # Example xNetworking
 $Global:DSCResourceName    = 'MSFT_x<ResourceName>' # Example MSFT_xFirewall
 # /TODO
 
-#region HEADER
-if ( (-not (Test-Path -Path '.\DSCResource.Tests\')) -or `
-     (-not (Test-Path -Path '.\DSCResource.Tests\TestHelper.psm1')) )
+#region HEADER (V2)
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
 else
 {
-    & git @('-C',(Join-Path -Path (Get-Location) -ChildPath '\DSCResource.Tests\'),'pull')
+    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
 }
-Import-Module .\DSCResource.Tests\TestHelper.psm1 -Force
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `
     -DSCResourceName $Global:DSCResourceName `

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -22,7 +22,7 @@ $Global:DSCResourceName    = 'MSFT_x<ResourceName>' # Example MSFT_xFirewall
 if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 else
 {

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -17,7 +17,7 @@ $Global:DSCModuleName      = 'x<ModuleName>' # Example xNetworking
 $Global:DSCResourceName    = 'MSFT_x<ResourceName>' # Example MSFT_xFirewall
 # /TODO
 
-#region HEADER (V2)
+#region HEADER
 [String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
 if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )

--- a/Tests.Template/unit_template.ps1
+++ b/Tests.Template/unit_template.ps1
@@ -17,17 +17,18 @@ $Global:DSCModuleName      = 'x<ModuleName>' # Example xNetworking
 $Global:DSCResourceName    = 'MSFT_x<ResourceName>' # Example MSFT_xFirewall
 # /TODO
 
-#region HEADER
-if ( (-not (Test-Path -Path '.\DSCResource.Tests\')) -or `
-     (-not (Test-Path -Path '.\DSCResource.Tests\TestHelper.psm1')) )
+#region HEADER (V2)
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
 else
 {
-    & git @('-C',(Join-Path -Path (Get-Location) -ChildPath '\DSCResource.Tests\'),'pull')
+    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
 }
-Import-Module .\DSCResource.Tests\TestHelper.psm1 -Force
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `
     -DSCResourceName $Global:DSCResourceName `

--- a/Tests.Template/unit_template.ps1
+++ b/Tests.Template/unit_template.ps1
@@ -22,7 +22,7 @@ $Global:DSCResourceName    = 'MSFT_x<ResourceName>' # Example MSFT_xFirewall
 if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 else
 {

--- a/Tests.Template/unit_template.ps1
+++ b/Tests.Template/unit_template.ps1
@@ -17,7 +17,7 @@ $Global:DSCModuleName      = 'x<ModuleName>' # Example xNetworking
 $Global:DSCResourceName    = 'MSFT_x<ResourceName>' # Example MSFT_xFirewall
 # /TODO
 
-#region HEADER (V2)
+#region HEADER
 [String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
 if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )


### PR DESCRIPTION
See https://github.com/PowerShell/DscResource.Tests/issues/24

This PR changes the Unit/Integration tests header region so that ```Invoke-Pester``` is not required to be run from the module root folder, but can now be run from any subfolder within ```tests```.

A Version number has also been added to the Header region comments so that it will be easier to see if the region has been updated should the template change in future.