### PR TITLE
Remove default x and MSFT_ from unit/integration test templates - Fixes #82

### DIFF
--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -231,3 +231,18 @@ function New-EtwEvent
     # Implementation
  }
 ```
+
+Call cmdlets using all named parameters instead of positional parameters
+------------------------------------------------------------------------
+
+**Bad:**
+```powershell
+Get-Childitem c:\documents *.md
+```
+
+The above code breaks this rule using by calling ```Get-ChildItem``` passing positional parameters instead of named parameters.
+
+**Good:**
+```powershell
+Get-ChildItem -Path c:\documents -filer *.md
+```

--- a/Tests.Template/integration_config_template.ps1
+++ b/Tests.Template/integration_config_template.ps1
@@ -3,21 +3,22 @@
    DSC Configuration Template for DSC Resource Integration tests.
 .DESCRIPTION
    To Use:
-     1. Copy to \Tests\Integration\ folder and rename MSFT_<ResourceName>.config.ps1 (e.g. MSFT_xFirewall.config.ps1)
+     1. Copy to \Tests\Integration\ folder and rename <ResourceName>.config.ps1 (e.g. MSFT_xFirewall.config.ps1)
      2. Customize TODO sections.
 
 .NOTES
 #>
 
 
-# TODO: Modify ResourceName
-configuration 'MSFT_<ResourceName>_config' {
-    Import-DscResource -Name 'MSFT_<ResourceName>'
+# TODO: Modify ResourceName (e.g. MSFT_xFirewall_config)
+configuration <ResourceName>_config {
+    # TODO: Modify ModuleName (e.g. xNetworking)
+    Import-DscResource -ModuleName '<ModuleName>'
     node localhost {
-       # TODO: Modify ResourceName
-       <ResourceName> Integration_Test {
+        # TODO: Modify ResourceNameFriendlyName (e.g. xFirewall Integration_Test)
+        <ResourceNameFriendlyName> Integration_Test {
             # TODO: Fill Configuration Code Here
-       }
+        }
     }
 }
 

--- a/Tests.Template/integration_config_template.ps1
+++ b/Tests.Template/integration_config_template.ps1
@@ -15,8 +15,8 @@ configuration <ResourceName>_config {
     # TODO: Modify ModuleName (e.g. xNetworking)
     Import-DscResource -ModuleName '<ModuleName>'
     node localhost {
-        # TODO: Modify ResourceNameFriendlyName (e.g. xFirewall Integration_Test)
-        <ResourceNameFriendlyName> Integration_Test {
+        # TODO: Modify ResourceFriendlyName (e.g. xFirewall Integration_Test)
+        <ResourceFriendlyName> Integration_Test {
             # TODO: Fill Configuration Code Here
         }
     }

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -3,9 +3,9 @@
    Template for creating DSC Resource Integration Tests
 .DESCRIPTION
    To Use:
-     1. Copy to \Tests\Integration\ folder and rename MSFT_x<ResourceName>.Integration.tests.ps1
+     1. Copy to \Tests\Integration\ folder and rename <ResourceName>.Integration.tests.ps1 (e.g. MSFT_xNeworking.Integration.tests.ps1)
      2. Customize TODO sections.
-     3. Create test DSC Configurtion file MSFT_x<ResourceName>.config.ps1 from integration_config_template.ps1 file.
+     3. Create test DSC Configurtion file <ResourceName>.config.ps1 (e.g. MSFT_xNeworking.config.ps1) from integration_config_template.ps1 file.
 
 .NOTES
    Code in HEADER, FOOTER and DEFAULT TEST regions are standard and may be moved into
@@ -13,8 +13,8 @@
 #>
 
 # TODO: Customize these parameters...
-$Global:DSCModuleName      = 'x<ModuleName>' # Example xNetworking
-$Global:DSCResourceName    = 'MSFT_x<ResourceName>' # Example MSFT_xFirewall
+$Global:DSCModuleName      = '<ModuleName>' # Example xNetworking
+$Global:DSCResourceName    = '<ResourceName>' # Example MSFT_xFirewall
 # /TODO
 
 #region HEADER

--- a/Tests.Template/unit_template.ps1
+++ b/Tests.Template/unit_template.ps1
@@ -3,7 +3,7 @@
    Template for creating DSC Resource Unit Tests
 .DESCRIPTION
    To Use:
-     1. Copy to \Tests\Unit\ folder and rename MSFT_x<ResourceName>.tests.ps1
+     1. Copy to \Tests\Unit\ folder and rename <ResourceName>.tests.ps1 (e.g. MSFT_xFirewall.tests.ps1)
      2. Customize TODO sections.
 
 .NOTES
@@ -13,8 +13,8 @@
 
 
 # TODO: Customize these parameters...
-$Global:DSCModuleName      = 'x<ModuleName>' # Example xNetworking
-$Global:DSCResourceName    = 'MSFT_x<ResourceName>' # Example MSFT_xFirewall
+$Global:DSCModuleName      = '<ModuleName>' # Example xNetworking
+$Global:DSCResourceName    = '<ResourceName>' # Example MSFT_xFirewall
 # /TODO
 
 #region HEADER


### PR DESCRIPTION
This fixes issue #82.

It also corrects these issues in Tests.Template/integration_config_template.ps1:
1. removes quotes from ```configuration '<ResourceName>_config' {``` as they shouldn't be there.
2. Uses ```<ResourceFriendlyName>``` instead of ```<FriendlyName>``` in the node resource.
3. Imports the DSC Resource module instead of just a specific resource (to match all existing integration tests).

Thanks