### PR TITLE
updated the unit/integration templates to not have to be dependent on git

### DIFF
--- a/Tests.Template/changelist.md
+++ b/Tests.Template/changelist.md
@@ -9,12 +9,14 @@ When the templates are used to create or update tests in a DSC Resource the vers
 
 ## integration_template.ps1
 ### Version 1.1.0
-* Getting rid of git-dependency.
+* Getting rid of git-dependency.*
+ 
 ### Version 1.0.0
 * First release including version number.
 
 ## unit_template.ps1
 ### Version 1.1.0
-* Getting rid of git-dependency.
+* Getting rid of git-dependency.*
+
 ### Version 1.0.0
 * First release including version number.

--- a/Tests.Template/changelist.md
+++ b/Tests.Template/changelist.md
@@ -9,14 +9,14 @@ When the templates are used to create or update tests in a DSC Resource the vers
 
 ## integration_template.ps1
 ### Version 1.1.0
-* Getting rid of git-dependency.*
+* Getting rid of git-dependency.
  
 ### Version 1.0.0
 * First release including version number.
 
 ## unit_template.ps1
 ### Version 1.1.0
-* Getting rid of git-dependency.*
+* Getting rid of git-dependency.
 
 ### Version 1.0.0
 * First release including version number.

--- a/Tests.Template/changelist.md
+++ b/Tests.Template/changelist.md
@@ -8,9 +8,13 @@ When the templates are used to create or update tests in a DSC Resource the vers
 * First release including version number.
 
 ## integration_template.ps1
+### Version 1.1.0
+* Getting rid of git-dependency.
 ### Version 1.0.0
 * First release including version number.
 
 ## unit_template.ps1
+### Version 1.1.0
+* Getting rid of git-dependency.
 ### Version 1.0.0
 * First release including version number.

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -25,10 +25,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -18,7 +18,7 @@ $Global:DSCResourceName    = '<ResourceName>' # Example MSFT_xFirewall
 # /TODO
 
 #region HEADER
-# Integration Test Template Version: 1.0.0
+# Integration Test Template Version: 1.1.0
 [String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
 if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )

--- a/Tests.Template/unit_template.ps1
+++ b/Tests.Template/unit_template.ps1
@@ -25,10 +25,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests.Template/unit_template.ps1
+++ b/Tests.Template/unit_template.ps1
@@ -18,7 +18,7 @@ $Global:DSCResourceName    = '<ResourceName>' # Example MSFT_xFirewall
 # /TODO
 
 #region HEADER
-# Unit Test Template Version: 1.0.0
+# Unit Test Template Version: 1.1.0
 [String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
 if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )


### PR DESCRIPTION
Now, as long as the DSCResource.Tests is already in the module (which it will be for the modules in the gallery) then there will not be any dependencies on git. Will be updating the rest of the modules as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/128)
<!-- Reviewable:end -->