### PR TITLE
Rename of xSharePoint in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ All DSC modules in the DscResources should have tests written using [Pester](htt
 It is required that you provide adequate coverage for the code you change.  The following projects have tests which you can use as examples:
 * [xNetworking](https://github.com/PowerShell/xNetworking/tree/dev/Tests) 
 * [xDhcpServer](https://github.com/PowerShell/xDhcpServer/tree/master/Tests)
-* [xSharepoint](https://github.com/PowerShell/xSharePoint/tree/master/Tests/xSharePoint)
+* [SharePointDsc](https://github.com/PowerShell/SharePointDsc/tree/master/Tests)
 
 We highly encourage you to use [tests templates](https://github.com/PowerShell/DscResources/tree/master/Tests.Template) when creating tests for DSC resources. Please refer to the [testing guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) for information on how to use the templates.
 


### PR DESCRIPTION
A quick fix to reflect the recent rename of xSharePoint to SharePointDsc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/142)
<!-- Reviewable:end -->
