### PR TITLE
Splatting not back tick

### DIFF
--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -131,7 +131,11 @@ function Set-ServerName
 ```
 
 ### Correct Format for Long Function Calls
-When calling a function with many parameters, if the line exceeds the line character limit, separate each parameter onto its own line.
+When calling a function with many parameters, if the line exceeds the line character limit, parameter splatting should be used.
+More help on splatting can be found using the command
+```powershell
+get-help about_splatting
+```
 Make sure hashtable parameters are also properly formatted with multiple lines and the proper indentation.
 
 **Bad:**
@@ -141,7 +145,7 @@ $superLongVariableName = Get-MySuperLongVariablePlease -MySuperLongHashtablePara
 
 **Good:**
 ```powershell
-$mySuperLongVariablePleaseParams = @{
+$getMySuperLongVariablePleaseParams = @{
     mySuperLongHashtableParameter @{ 
         mySuperLongKey1 = 'MySuperLongValue1'
         mySuperLongKey2 = 'MySuperLongValue2'
@@ -150,7 +154,7 @@ $mySuperLongVariablePleaseParams = @{
     verbose = $true
 }
 
-$superLongVariableName = Get-MySuperLongVariablePlease @mySuperLongVariablePleaseParams
+$superLongVariableName = Get-MySuperLongVariablePlease @getMySuperLongVariablePleaseParams
 ```
 
 ### Correct Format for Arrays

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -141,16 +141,16 @@ $superLongVariableName = Get-MySuperLongVariablePlease -MySuperLongHashtablePara
 
 **Good:**
 ```powershell
-$MySuperLongVariablePleaseParams = @{
-    MySuperLongHashtableParameter @{ 
-        MySuperLongKey1 = 'MySuperLongValue1'
-        MySuperLongKey2 = 'MySuperLongValue2'
+$mySuperLongVariablePleaseParams = @{
+    mySuperLongHashtableParameter @{ 
+        mySuperLongKey1 = 'MySuperLongValue1'
+        mySuperLongKey2 = 'MySuperLongValue2'
     }
-    MySuperLongStringParameter = '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'
-    Verbose = $true
+    mySuperLongStringParameter = '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'
+    verbose = $true
 }
 
-$superLongVariableName = Get-MySuperLongVariablePlease @MySuperLongVariablePleaseParams
+$superLongVariableName = Get-MySuperLongVariablePlease @mySuperLongVariablePleaseParams
 ```
 
 ### Correct Format for Arrays

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -141,14 +141,16 @@ $superLongVariableName = Get-MySuperLongVariablePlease -MySuperLongHashtablePara
 
 **Good:**
 ```powershell
-$superLongVariableName = Get-MySuperLongVariablePlease `
-    -MySuperLongHashtableParameter @{ 
+$MySuperLongVariablePleaseParams = @{
+    MySuperLongHashtableParameter @{ 
         MySuperLongKey1 = 'MySuperLongValue1'
         MySuperLongKey2 = 'MySuperLongValue2'
-    } `
-    -MySuperLongStringParameter '12345678901234567890123456789012345678901234567890' + `         
-        '1234567890123456789012345678901234567890123456789012345678901234567890' `
-    -Verbose
+    }
+    MySuperLongStringParameter = '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'
+    Verbose = $true
+}
+
+$superLongVariableName = Get-MySuperLongVariablePlease @MySuperLongVariablePleaseParams
 ```
 
 ### Correct Format for Arrays


### PR DESCRIPTION
Executing long commands should use splatting and not back tick. See: https://github.com/PoshCode/PowerShellPracticeAndStyle/blob/master/Style%20Guide/Readability.md READ-02.

I also suggest that in this case, violating the 100 chat limit is OK as it is significantly more readable and less error prone (in my experience). 
1. I have seen situations where the string concatenation can lead to corruption of input, whilst extremely, extremely rare, it is worth highlighting.
2. The concatenation makes code more difficult to read.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/151)
<!-- Reviewable:end -->
