### PR TITLE
Changes to StyleGuidelines (fixes #209, fixes #223)

### DIFF
--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -769,9 +769,13 @@ function Write-Nothing
 
 ## Parameters
 ### Correct Format for Parameter Block
-An empty parameter block should be displayed on its own line like this: ```param ()```
-Otherwise, the opening and closing parentheses should each be on their own line.
-All text inside the parameter block should be indented once.
+
+- An empty parameter block should be displayed on its own line like this: `param ()`.
+- An non-empty parameter block should have the opening and closing parentheses on their own line.
+- All text inside the parameter block should be indented once.
+- Every parameter must include regardless if it actually requires decoration: `[Parameter()]`.
+- A parameter that is mandatory should contain this decoration: `[Parameter(Mandatory = $true)]`.
+- A parameter that is not mandatory should _not_ contain a `Mandatory` decoration in the `[Parameter()]`.
 
 **Bad**:
 ```powershell
@@ -798,6 +802,38 @@ function Write-Text
 }
 ```
 
+**Bad**:
+
+```PowerShell
+function Write-Text
+{
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Text
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $PrefixText
+
+        [Boolean]
+        $AsWarning = $false
+    )
+
+    if ($AsWarning)
+    {
+        Write-Warning -Message "$PrefixText - $Text"
+    }
+    else
+    {
+        Write-Verbose -Message "$PrefixText - $Text"
+    }
+}
+```
+
 **Good**:
 ```powershell
 function Write-Nothing
@@ -821,6 +857,39 @@ function Write-Text
     )
     
     Write-Verbose -Message $Text
+}
+```
+
+**Good**:
+
+```PowerShell
+function Write-Text
+{
+    param
+    (
+        [Parameter(Mandatory = true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Text
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $PrefixText
+
+        [Parameter()]
+        [Boolean]
+        $AsWarning = $false
+    )
+
+    if ($AsWarning)
+    {
+        Write-Warning -Message "$PrefixText - $Text"
+    }
+    else
+    {
+        Write-Verbose -Message "$PrefixText - $Text"
+    }
 }
 ```
 

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -42,7 +42,7 @@ In order to provide clean and consistent code, please follow the style guideline
 - [Best Practices](#best-practices)
   - [Named Parameters Instead of Positional Parameters](#named-parameters-instead-of-positional-parameters)
   - [No Cmdlet Aliases](#no-cmdlet-aliases)
-  - [No backslash in paths](#no-backslash-in-paths)
+  - [No Backslash in Paths](#no-backslash-in-paths)
 
 ## Markdown Files
 
@@ -1276,9 +1276,9 @@ ls -File $root -Recurse | ? { @('.gitignore', '.mof') -contains $_.Extension }
 Get-ChildItem -File $root -Recurse | Where-Object { @('.gitignore', '.mof') -contains $_.Extension }
 ```
 
-### No backslash in paths
+### No Backslash in Paths
 
-To support resources to be used cross-platform no backslashes can be used in paths. Instead `Join-Path` and `Split-Path` should be used to build a path.
+To support the possibility of cross-platform use in the future, backslashes should not be used within a path. Instead `Join-Path` and `Split-Path` should be used to build a path.
 
 **Bad:**
 
@@ -1291,5 +1291,7 @@ Import-Module -Name "$currentPath\..\..\CommonResourceHelper.psm1"
 
 ```PowerShell
 $currentPath = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
-Import-Module -Name (Join-Path -Path (Split-Path -Path (Split-Path -Path $currentPath -Parent) -Parent) -ChildPath 'CommonResourceHelper.psm1')
+$modulePath = (Join-Path -Path (Split-Path -Path (Split-Path -Path $currentPath -Parent) -Parent) `
+                         -ChildPath 'CommonResourceHelper.psm1')
+Import-Module -Name $modulePath
 ```

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -773,7 +773,7 @@ function Write-Nothing
 - An empty parameter block should be displayed on its own line like this: `param ()`.
 - A non-empty parameter block should have the opening and closing parentheses on their own line.
 - All text inside the parameter block should be indented once.
-- Every parameter should include the `[Parameter()]` decoration regardless of whether it is actually used or not.
+- Every parameter should include the `[Parameter()]` attribute, regardless of whether the attribute requires decoration or not.
 - A parameter that is mandatory should contain this decoration: `[Parameter(Mandatory = $true)]`.
 - A parameter that is not mandatory should _not_ contain a `Mandatory` decoration in the `[Parameter()]`.
 

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -771,9 +771,9 @@ function Write-Nothing
 ### Correct Format for Parameter Block
 
 - An empty parameter block should be displayed on its own line like this: `param ()`.
-- An non-empty parameter block should have the opening and closing parentheses on their own line.
+- A non-empty parameter block should have the opening and closing parentheses on their own line.
 - All text inside the parameter block should be indented once.
-- Every parameter must include regardless if it actually requires decoration: `[Parameter()]`.
+- Every parameter should include the `[Parameter()]` decoration regardless of whether it is actually used or not.
 - A parameter that is mandatory should contain this decoration: `[Parameter(Mandatory = $true)]`.
 - A parameter that is not mandatory should _not_ contain a `Mandatory` decoration in the `[Parameter()]`.
 

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -42,6 +42,7 @@ In order to provide clean and consistent code, please follow the style guideline
 - [Best Practices](#best-practices)
     - [Named Parameters Instead of Positional Parameters](#named-parameters-instead-of-positional-parameters)
     - [No Cmdlet Aliases](#no-cmdlet-aliases)
+    - [No backslash in paths](#no-backslash-in-paths)
 
 ## Markdown Files
 If a paragraph includes more than one sentence, end each sentence with a newline.
@@ -1156,4 +1157,22 @@ ls -File $root -Recurse | ? { @('.gitignore', '.mof') -contains $_.Extension }
 **Good** 
 ```Powershell
 Get-ChildItem -File $root -Recurse | Where-Object { @('.gitignore', '.mof') -contains $_.Extension } 
+```
+
+### No backslash in paths
+
+To support resources to be used cross-platform no backslashes can be used in paths. Instead `Join-Path` and `Split-Path` should be used to build a path.
+
+#### Bad
+
+```PowerShell
+$currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+Import-Module -Name "$currentPath\..\..\CommonResourceHelper.psm1"
+```
+
+#### Good
+
+```PowerShell
+$currentPath = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
+Import-Module -Name (Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'CommonResourceHelper.psm1')
 ```

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -4,72 +4,79 @@ In order to provide clean and consistent code, please follow the style guideline
 
 ## Table of Contents
 
-- [Markdown Files](#markdown-files)  
-- [General](#general)  
-    - [Correct File Encoding](#correct-file-encoding)
-    - [Descriptive Names](#descriptive-names)  
-    - [Correct Format for Long Function Calls](#correct-format-for-long-function-calls)  
-    - [Correct Format for Arrays](#correct-format-for-arrays)  
-    - [Correct Format for Hashtables or Objects](#correct-format-for-hashtables-or-objects)  
-    - [Correct Format for Comments](#correct-format-for-comments)  
-- [Whitespace](#whitespace)  
-    - [Indentation](#indentation)
-    - [No Trailing Whitespace After Backticks](#no-trailing-whitespace-after-backticks)
-    - [Newline at End of File](#newline-at-end-of-file)  
-    - [Newline Character Encoding](#newline-character-encoding)  
-    - [No More Than Two Consecutive Newlines](#no-more-than-two-consecutive-newlines)  
-    - [One Newline Before Braces](#one-newline-before-braces)  
-    - [One Newline After Opening Brace](#one-newline-after-opening-brace)  
-    - [Two Newlines After Closing Brace](#two-newlines-after-closing-brace)  
-    - [One Space Between Type and Variable Name](#one-space-between-type-and-variable-name)  
-    - [One Space on Either Side of Operators](#one-space-on-either-side-of-operators)  
-    - [One Space Between Keyword and Parenthesis](#one-space-between-keyword-and-parenthesis)
+- [Markdown Files](#markdown-files)
+- [General](#general)
+- [Correct File Encoding](#correct-file-encoding)
+  - [Descriptive Names](#descriptive-names)
+  - [Correct Format for Long Function Calls](#correct-format-for-long-function-calls)
+  - [Correct Format for Arrays](#correct-format-for-arrays)
+  - [Correct Format for Hashtables or Objects](#correct-format-for-hashtables-or-objects)
+  - [Correct Format for Comments](#correct-format-for-comments)
+- [Whitespace](#whitespace)
+  - [Indentation](#indentation)
+  - [No Trailing Whitespace After Backticks](#no-trailing-whitespace-after-backticks)
+  - [Newline at End of File](#newline-at-end-of-file)
+  - [Newline Character Encoding](#newline-character-encoding)
+  - [No More Than Two Consecutive Newlines](#no-more-than-two-consecutive-newlines)
+  - [One Newline Before Braces](#one-newline-before-braces)
+  - [One Newline After Opening Brace](#one-newline-after-opening-brace)
+  - [Two Newlines After Closing Brace](#two-newlines-after-closing-brace)
+  - [One Space Between Type and Variable Name](#one-space-between-type-and-variable-name)
+  - [One Space on Either Side of Operators](#one-space-on-either-side-of-operators)
+  - [One Space Between Keyword and Parenthesis](#one-space-between-keyword-and-parenthesis)
 - [Functions](#functions)
-    - [Function Names Use Pascal Case](#function-names-use-pascal-case)
-    - [Function Names Use Verb-Noun Format](#function-names-use-verb-noun-format)
-    - [Function Names Use Approved Verbs](#function-names-use-approved-verbs)
-    - [Functions Have Comment-Based Help](#functions-have-comment-based-help)
-    - [Parameter Block at Top of Function](#parameter-block-at-top-of-function)
+  - [Function Names Use Pascal Case](#function-names-use-pascal-case)
+  - [Function Names Use Verb-Noun Format](#function-names-use-verb-noun-format)
+  - [Function Names Use Approved Verbs](#function-names-use-approved-verbs)
+  - [Functions Have Comment-Based Help](#functions-have-comment-based-help)
+  - [Parameter Block at Top of Function](#parameter-block-at-top-of-function)
 - [Parameters](#parameters)
-    - [Correct Format for Parameter Block](#correct-format-for-parameter-block)
-    - [Parameter Names Use Pascal Case](#parameter-names-use-pascal-case)
-    - [Parameters Separated by One Line](#parameters-separated-by-one-line)
-    - [Parameter Type on Line Above](#parameter-type-on-line-above)
-    - [Parameter Attributes on Separate Lines](#parameter-attributes-on-separate-lines)
+  - [Correct Format for Parameter Block](#correct-format-for-parameter-block)
+  - [Parameter Names Use Pascal Case](#parameter-names-use-pascal-case)
+  - [Parameters Separated by One Line](#parameters-separated-by-one-line)
+  - [Parameter Type on Line Above](#parameter-type-on-line-above)
+  - [Parameter Attributes on Separate Lines](#parameter-attributes-on-separate-lines)
 - [Variables](#variables)
-    - [Variable Names Use Camel Case](#variable-names-use-camel-case)
-    - [Script, Environment and Global Variable Names Include Scope](#script-environment-and-global-variable-names-include-scope)
+  - [Variable Names Use Camel Case](#variable-names-use-camel-case)
+  - [Script, Environment and Global Variable Names Include Scope](#script-environment-and-global-variable-names-include-scope)
 - [Best Practices](#best-practices)
-    - [Named Parameters Instead of Positional Parameters](#named-parameters-instead-of-positional-parameters)
-    - [No Cmdlet Aliases](#no-cmdlet-aliases)
-    - [No backslash in paths](#no-backslash-in-paths)
+  - [Named Parameters Instead of Positional Parameters](#named-parameters-instead-of-positional-parameters)
+  - [No Cmdlet Aliases](#no-cmdlet-aliases)
+  - [No backslash in paths](#no-backslash-in-paths)
 
 ## Markdown Files
+
 If a paragraph includes more than one sentence, end each sentence with a newline.
 GitHub will still render the sentences as a single paragraph, but the readability of `git diff` will be greatly improved.
 
 ## General
+
 ### Correct File Encoding
-Make sure all files are encoded using UTF-8, except mof files which should be encoded using ASCII.  
+
+Make sure all files are encoded using UTF-8, except mof files which should be encoded using ASCII.
 You can use ```ConvertTo-UTF8``` and ```ConvertTo-ASCII``` to convert a file to UTF-8 or ASCII.
 
-### Descriptive Names 
+### Descriptive Names
+
 Use descriptive, clear, and full names for all variables, parameters, and functions.
 All names must be at least more than **2** characters.
 No abbreviations should be used.
 
 **Bad:**
-```powershell
+
+```PowerShell
 $r = Get-RdsHost
 ```
 
 **Bad:**
-```powershell
+
+```PowerShell
 $frtytw = 42
 ```
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-Thing
 {
     ...
@@ -77,7 +84,8 @@ function Get-Thing
 ```
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Set-ServerName
 {
     param
@@ -89,17 +97,20 @@ function Set-ServerName
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 $remoteDesktopSessionHost = Get-RemoteDesktopSessionHost
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 $fileCharacterLimit = 42
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-ArchiveFileHandle
 {
     ...
@@ -107,7 +118,8 @@ function Get-ArchiveFileHandle
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Set-ServerName
 {
     param
@@ -119,22 +131,27 @@ function Set-ServerName
 ```
 
 ### Correct Format for Long Function Calls
+
 When calling a function with many long parameters, use parameter splatting.
 More help on splatting can be found using the command:
-```powershell
+
+```PowerShell
 Get-Help -Name 'About_Splatting'
 ```
+
 Make sure hashtable parameters are still properly formatted with multiple lines and the proper indentation.
 
 **Bad:**
-```powershell
+
+```PowerShell
 $superLongVariableName = Get-MySuperLongVariablePlease -MySuperLongHashtableParameter @{ MySuperLongKey1 = 'MySuperLongValue1'; MySuperLongKey2 = 'MySuperLongValue2' } -MySuperLongStringParameter '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890' -Verbose
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 $getMySuperLongVariablePleaseParams = @{
-    MySuperLongHashtableParameter = @{ 
+    MySuperLongHashtableParameter = @{
         mySuperLongKey1 = 'MySuperLongValue1'
         mySuperLongKey2 = 'MySuperLongValue2'
     }
@@ -146,21 +163,24 @@ $superLongVariableName = Get-MySuperLongVariablePlease @getMySuperLongVariablePl
 ```
 
 ### Correct Format for Arrays
+
 Arrays should be written in the following format.
 Arrays should be writen on one line unless they exceed the line character limit.
 There should be a single space between each element in the array.
 Hashtables should not be declared inside an array.
 
-**Bad**:
-```powershell
+**Bad:**
+
+```PowerShell
 $array = @( 'one', `
 'two', `
-'three' 
+'three'
 )
 ```
 
-**Good**:
-```powershell
+**Good:**
+
+```PowerShell
 $hashtable = @{
     Key = "Value"
 }
@@ -169,23 +189,27 @@ $array = @( 'one', 'two', 'three', $hashtable )
 ```
 
 ### Correct Format for Hashtables or Objects
+
 Hashtables and Objects should be written in the following format.
 Each property should be on its own line indented once.
 
-**Bad**:
-```powershell
+**Bad:**
+
+```PowerShell
 $hashtable = @{Key1 = 'Value1';Key2 = 2;Key3 = '3'}
 ```
 
-**Bad**:
-```powershell
+**Bad:**
+
+```PowerShell
 $hashtable = @{ Key1 = 'Value1'
 Key2 = 2
 Key3 = '3' }
 ```
 
-**Good**:
-```powershell
+**Good:**
+
+```PowerShell
 $hashtable = @{
     Key1 = 'Value1'
     Key2 = 2
@@ -193,8 +217,9 @@ $hashtable = @{
 }
 ```
 
-**Good**:
-```powershell
+**Good:**
+
+```PowerShell
 $hashtable = @{
     Key1 = 'Value1'
     Key2 = 2
@@ -206,6 +231,7 @@ $hashtable = @{
 ```
 
 ### Correct Format for Comments
+
 There should not be any commented-out code in checked-in files.
 The first letter of the comment should be captialized.
 
@@ -219,8 +245,9 @@ The brackets should be indented the same amount as the following line of code.
 
 Formatting help-comments for functions has a few more specific rules that can be found [here](#all-functions-must-have-comment-based-help).
 
-**Bad**:
-```powershell
+**Bad:**
+
+```PowerShell
 function Get-MyVariable
 {#this is a bad comment
     [CmdletBinding()]
@@ -233,13 +260,14 @@ function Get-MyVariable
 }
 ```
 
-**Bad**:
-```powershell
+**Bad:**
+
+```PowerShell
 function Get-MyVariable
 {
     [CmdletBinding()]
     param ()
-    
+
     # this is a bad comment
     # On multiple lines
     foreach ($example in $examples)
@@ -250,30 +278,32 @@ function Get-MyVariable
 }
 ```
 
-**Good**:
-```powershell
+**Good:**
+
+```PowerShell
 function Get-MyVariable
 {
     # This is a good comment
     [CmdletBinding()]
     param ()
-    
+
     # This is a good comment
     foreach ($example in $examples)
     {
         # This is a good comment
-        Write-Verbose -Message $example 
+        Write-Verbose -Message $example
     }
 }
 ```
 
-**Good**:
-```powershell
+**Good:**
+
+```PowerShell
 function Get-MyVariable
 {
     [CmdletBinding()]
     param ()
-    
+
     <#
         This is a good comment
         on multiple lines
@@ -286,25 +316,32 @@ function Get-MyVariable
 ```
 
 ## Whitespace
-### Indentation 
+
+### Indentation
+
 For all indentation, use **4** spaces instead of tabs.
 There should be no tab characters in the file unless they are in a here-string.
 
 ### No Trailing Whitespace After Backticks
+
 Backticks should always be directly followed by a newline
 
 ### Newline at End of File
-All files must end with a newline, see [StackOverflow.](http://stackoverflow.com/questions/5813311/no-newline-at-end-of-file) 
+
+All files must end with a newline, see [StackOverflow.](http://stackoverflow.com/questions/5813311/no-newline-at-end-of-file)
 
 ### Newline Character Encoding
+
 Save [newlines](http://en.wikipedia.org/wiki/Newline) using CR+LF instead of CR.
 For interoperability reasons, we recommend that you follow [these instructions](GettingStartedWithGitHub.md#setup-git) when installing Git on Windows so that newlines saved to GitHub are simply CRs.
 
-### No More Than Two Consecutive Newlines 
+### No More Than Two Consecutive Newlines
+
 Code should not contain more than two consecutive newlines unless they are contained in a here-string.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-MyValue
 {
     Write-Verbose -Message 'Getting MyValue'
@@ -315,7 +352,8 @@ function Get-MyValue
 ```
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-MyValue
 {
     Write-Verbose -Message 'Getting MyValue'
@@ -331,7 +369,8 @@ function Write-Log
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-MyValue
 {
     Write-Verbose -Message 'Getting MyValue'
@@ -340,7 +379,8 @@ function Get-MyValue
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-MyValue
 {
     Write-Verbose -Message 'Getting MyValue'
@@ -354,17 +394,20 @@ function Write-Log
 ```
 
 ### One Newline Before Braces
+
 Each curly brace should be preceded by a newline unless assigning to a variable.
 
 **Bad:**
-```powershell
+
+```PowerShell
 if ($booleanValue) {
     Write-Verbose -Message "Boolean is $booleanValue"
 }
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 if ($booleanValue)
 {
     Write-Verbose -Message "Boolean is $booleanValue"
@@ -374,7 +417,8 @@ if ($booleanValue)
 When assigning to a variable, opening curly braces should be on the same line as the assignment operator.
 
 **Bad:**
-```powershell
+
+```PowerShell
 $scriptBlockVariable =
 {
     Write-Verbose -Message 'Executing script block'
@@ -382,7 +426,8 @@ $scriptBlockVariable =
 ```
 
 **Bad:**
-```powershell
+
+```PowerShell
 $hashtableVariable =
 @{
     Key1 = 'Value1'
@@ -391,14 +436,16 @@ $hashtableVariable =
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 $scriptBlockVariable = {
     Write-Verbose -Message 'Executing script block'
 }
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 $hashtableVariable = @{
     Key1 = 'Value1'
     Key2 = 'Value2'
@@ -406,10 +453,12 @@ $hashtableVariable = @{
 ```
 
 ### One Newline After Opening Brace
+
 Each opening curly brace should be followed by only one newline.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-MyValue
 {
 
@@ -420,7 +469,8 @@ function Get-MyValue
 ```
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-MyValue
 { Write-Verbose -Message 'Getting MyValue'
 
@@ -429,7 +479,8 @@ function Get-MyValue
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-MyValue
 {
     Write-Verbose -Message 'Getting MyValue'
@@ -438,11 +489,13 @@ function Get-MyValue
 ```
 
 ### Two Newlines After Closing Brace
+
 Each closing curly brace **ending** a function, conditional block, loop, etc. should be followed by exactly two newlines unless it is directly followed by another closing brace.
 If the closing brace is followed by another closing brace or continues a conditional or switch block, there should be only one newline after the closing brace.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-MyValue
 {
     Write-Verbose -Message 'Getting MyValue'
@@ -451,7 +504,8 @@ function Get-MyValue
 ```
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-MyValue
 { Write-Verbose -Message 'Getting MyValue'
 
@@ -459,22 +513,23 @@ function Get-MyValue
     {
         return $MyValue
     }
-    
+
     else
     {
         return 0
     }
-    
+
 }
 Get-MyValue
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-MyValue
 {
     Write-Verbose -Message 'Getting MyValue'
-    
+
     if ($myBoolean)
     {
         return $MyValue
@@ -489,51 +544,57 @@ Get-MyValue
 ```
 
 ### One Space Between Type and Variable Name
+
 If you must declare a variable type, type declarations should be separated from the variable name by a single space.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
     param ()
-    
+
     [Int]$number = 2
 }
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
     param ()
-    
+
     [Int] $number = 2
 }
 ```
 
 ### One Space on Either Side of Operators
+
 There should be one blank space on either side of all operators.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
     param ()
-    
+
     $number=2+4-5*9/6
 }
 ```
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
     param ()
-    
+
     if ('example'-eq'example'-or'magic')
     {
         Write-Verbose -Message 'Example found.'
@@ -542,23 +603,25 @@ function Get-TargetResource
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
     param ()
-    
+
     $number = 2 + 4 - 5 * 9 / 6
 }
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
     param ()
-    
+
     if ('example' -eq 'example' -or 'magic')
     {
         Write-Verbose -Message 'Example found.'
@@ -567,20 +630,22 @@ function Get-TargetResource
 ```
 
 ### One Space Between Keyword and Parenthesis
+
 If a keyword is followed by a parenthesis, there should be single space between the keyword and the parenthesis.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
     param ()
-    
+
     if('example' -eq 'example' -or 'magic')
     {
         Write-Verbose -Message 'Example found.'
     }
-    
+
     foreach($example in $examples)
     {
         Write-Verbose -Message $example
@@ -589,17 +654,18 @@ function Get-TargetResource
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
     param ()
-    
+
     if ('example' -eq 'example' -or 'magic')
     {
         Write-Verbose -Message 'Example found.'
     }
-    
+
     foreach ($example in $examples)
     {
         Write-Verbose -Message $example
@@ -608,11 +674,14 @@ function Get-TargetResource
 ```
 
 ## Functions
+
 ### Function Names Use Pascal Case
+
 Function names must use PascalCase.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function get-targetresource
 {
     # ...
@@ -620,7 +689,8 @@ function get-targetresource
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     # ...
@@ -628,10 +698,12 @@ function Get-TargetResource
 ```
 
 ### Function Names Use Verb-Noun Format
+
 All function names must follow the standard PowerShell Verb-Noun format.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function TargetResourceGetter
 {
     # ...
@@ -639,7 +711,8 @@ function TargetResourceGetter
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     # ...
@@ -647,10 +720,12 @@ function Get-TargetResource
 ```
 
 ### Function Names Use Approved Verbs
+
 All function names must use [approved verbs](https://msdn.microsoft.com/en-us/library/ms714428(v=vs.85).aspx).
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Normalize-String
 {
     # ...
@@ -658,7 +733,8 @@ function Normalize-String
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function ConvertTo-NormalizedString
 {
     # ...
@@ -666,11 +742,13 @@ function ConvertTo-NormalizedString
 ```
 
 ### Functions Have Comment-Based Help
+
 All functions should have comment-based help with the correct syntax directly above the function.
 Comment-help should include at least the SYNOPSIS section and a PARAMETER section for each parameter.
 
 **Bad:**
-```powershell
+
+```PowerShell
 # Creates an event
 function New-Event
 {
@@ -690,17 +768,18 @@ function New-Event
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 <#
     .SYNOPSIS
         Creates an event
-    
+
     .PARAMETER Message
         Message to write
-        
+
     .PARAMETER Channel
         Channel where message should be stored
-        
+
     .EXAMPLE
         New-Event -Message 'Attempting to connect to server' -Channel 'debug'
 #>
@@ -722,53 +801,59 @@ function New-Event
 ```
 
 ### Parameter Block at Top of Function
+
 There must be a parameter block decalred for every function.
 The parameter block must be at the top of the function and not declared next to the function name.
 Functions with no parameters should still display an empty parameter block.
 
-**Bad**:
-```powershell
+**Bad:**
+
+```PowerShell
 function Write-Text([Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][String]$Text)
 {
     Write-Verbose -Message $Text
 }
 ```
 
-**Bad**:
-```powershell
+**Bad:**
+
+```PowerShell
 function Write-Nothing
 {
     Write-Verbose -Message 'Nothing'
 }
 ```
 
-**Good**:
-```powershell
+**Good:**
+
+```PowerShell
 function Write-Text
 {
-    param 
+    param
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String]
         $Text
     )
-    
+
     Write-Verbose -Message $Text
 }
 ```
 
-**Good**:
-```powershell
+**Good:**
+
+```PowerShell
 function Write-Nothing
 {
     param ()
-    
+
     Write-Verbose -Message 'Nothing'
 }
 ```
 
 ## Parameters
+
 ### Correct Format for Parameter Block
 
 - An empty parameter block should be displayed on its own line like this: `param ()`.
@@ -778,32 +863,34 @@ function Write-Nothing
 - A parameter that is mandatory should contain this decoration: `[Parameter(Mandatory = $true)]`.
 - A parameter that is not mandatory should _not_ contain a `Mandatory` decoration in the `[Parameter()]`.
 
-**Bad**:
-```powershell
+**Bad:**
+
+```PowerShell
 function Write-Nothing
 {
-    param 
+    param
     (
-    
+
     )
-    
+
     Write-Verbose -Message 'Nothing'
 }
 ```
 
-**Bad**:
-```powershell
+**Bad:**
+
+```PowerShell
 function Write-Text
 {
     param([Parameter(Mandatory = $true)]
 [ValidateNotNullOrEmpty()]
                     [String] $Text )
-    
+
     Write-Verbose -Message $Text
 }
 ```
 
-**Bad**:
+**Bad:**
 
 ```PowerShell
 function Write-Text
@@ -835,33 +922,35 @@ function Write-Text
 }
 ```
 
-**Good**:
-```powershell
+**Good:**
+
+```PowerShell
 function Write-Nothing
 {
     param ()
-    
+
     Write-Verbose -Message 'Nothing'
 }
 ```
 
-**Good**:
-```powershell
+**Good:**
+
+```PowerShell
 function Write-Text
 {
-    param 
+    param
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String]
         $Text
     )
-    
+
     Write-Verbose -Message $Text
 }
 ```
 
-**Good**:
+**Good:**
 
 ```PowerShell
 function Write-Text
@@ -895,10 +984,12 @@ function Write-Text
 ```
 
 ### Parameter Names Use Pascal Case
+
 All parameters must use PascalCase.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -910,7 +1001,8 @@ function Get-TargetResource
 ```
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -922,7 +1014,8 @@ function Get-TargetResource
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -934,10 +1027,12 @@ function Get-TargetResource
 ```
 
 ### Parameters Separated by One Line
+
 Parameters must be separated by a single, blank line.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function New-Event
 {
     param
@@ -954,7 +1049,8 @@ function New-Event
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function New-Event
 {
     param
@@ -963,7 +1059,7 @@ function New-Event
         [ValidateNotNullOrEmpty()]
         [String]
         $Message,
-        
+
         [ValidateSet('operational', 'debug', 'analytic')]
         [String]
         $Channel = 'operational'
@@ -972,11 +1068,13 @@ function New-Event
 ```
 
 ### Parameter Type on Line Above
+
 The parameter type must be on its own line above the parameter name.
 If an attribute needs to follow the type, it should also have its own line between the parameter type and the parameter name.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -988,7 +1086,8 @@ function Get-TargetResource
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -1001,13 +1100,14 @@ function Get-TargetResource
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Get-TargetResource
 {
     [CmdletBinding()]
     param
     (
-        [PSCredential] 
+        [PSCredential]
         [Credential()]
         $MyCredential
     )
@@ -1015,7 +1115,8 @@ function Get-TargetResource
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function New-Event
 {
     param
@@ -1033,11 +1134,13 @@ function New-Event
 ```
 
 ### Parameter Attributes on Separate Lines
+
 Parameter attributes should each have their own line.
 All attributes should go above the parameter type, except those that *must* be between the type and the name.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function New-Event
 {
     param
@@ -1052,7 +1155,8 @@ function New-Event
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function New-Event
 {
     param
@@ -1072,10 +1176,12 @@ function New-Event
 ## Variables
 
 ### Variable Names Use Camel Case
+
 Variable names should use camelCase.
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Write-Log
 {
     $VerboseMessage = 'New log message'
@@ -1084,7 +1190,8 @@ function Write-Log
 ```
 
 **Bad:**
-```powershell
+
+```PowerShell
 function Write-Log
 {
     $verbosemessage = 'New log message'
@@ -1093,7 +1200,8 @@ function Write-Log
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 function Write-Log
 {
     $verboseMessage = 'New log message'
@@ -1102,12 +1210,14 @@ function Write-Log
 ```
 
 ### Script, Environment and Global Variable Names Include Scope
+
 Script, environment, and global variables must always include their scope in the variable name unless the 'using' scope is needed.
 The script and global scope specifications should be all in lowercase.
 Script and global variable names following the scope should use camelCase.
 
 **Bad:**
-```powershell
+
+```PowerShell
 $fileCount = 0
 $GLOBAL:MYRESOURCENAME = 'MyResource'
 
@@ -1119,7 +1229,8 @@ function New-File
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 $script:fileCount = 0
 $global:myResourceName = 'MyResource'
 
@@ -1133,46 +1244,52 @@ function New-File
 ## Best Practices
 
 ### Named Parameters Instead of Positional Parameters
+
 Call cmdlets using named parameters instead of positional parameters.
 
 **Bad:**
-```powershell
+
+```PowerShell
 Get-ChildItem C:\Documents *.md
 ```
 
 **Good:**
-```powershell
+
+```PowerShell
 Get-ChildItem -Path C:\Documents -Filter *.md
 ```
 
 ### No Cmdlet Aliases
+
 When calling a function use the full command not an alias.
 You can get the full command an alias is using by calling ```Get-Alias```.
 
-**Bad**
-```powershell
+**Bad:**
+
+```PowerShell
 ls -File $root -Recurse | ? { @('.gitignore', '.mof') -contains $_.Extension }
 ```
 
-**Good** 
+**Good:**
+
 ```Powershell
-Get-ChildItem -File $root -Recurse | Where-Object { @('.gitignore', '.mof') -contains $_.Extension } 
+Get-ChildItem -File $root -Recurse | Where-Object { @('.gitignore', '.mof') -contains $_.Extension }
 ```
 
 ### No backslash in paths
 
 To support resources to be used cross-platform no backslashes can be used in paths. Instead `Join-Path` and `Split-Path` should be used to build a path.
 
-#### Bad
+**Bad:**
 
 ```PowerShell
 $currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
 Import-Module -Name "$currentPath\..\..\CommonResourceHelper.psm1"
 ```
 
-#### Good
+**Good:**
 
 ```PowerShell
 $currentPath = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
-Import-Module -Name (Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'CommonResourceHelper.psm1')
+Import-Module -Name (Join-Path -Path (Split-Path -Path (Split-Path -Path $currentPath -Parent) -Parent) -ChildPath 'CommonResourceHelper.psm1')
 ```

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -867,7 +867,7 @@ function Write-Text
 {
     param
     (
-        [Parameter(Mandatory = true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String]
         $Text


### PR DESCRIPTION
FIxes #209
Fixes #223

* Added new guidelines for how to write parameters. 
* Added new guideline for not using backslash in paths. 

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/217)
<!-- Reviewable:end -->
