### PR TITLE
Fix DSCResource.Template/Readme.md markdown rule violations - Fixes #220

### DIFF
--- a/DscResource.Template/README.md
+++ b/DscResource.Template/README.md
@@ -1,6 +1,6 @@
-{AppVeyor build status badge for master branch}
-
 # {ModuleName}
+
+{AppVeyor build status badge for master branch}
 
 { Description of the module - Please include any requirements for running all resources in this module (e.g. Must run on Windows Server OS, must have Exchange already installed) - Requirements specific to only certain resources in this module may be listed below with the description of those resources. }
 
@@ -8,6 +8,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## How to Contribute
+
 If you would like to contribute to this repository, please read the DSC Resource Kit [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
 
 ## Resources
@@ -43,6 +44,6 @@ If you would like to contribute to this repository, please read the DSC Resource
 ### {1.0.0.0}
 
 * Initial release with the following resources:
-    * {Resource1}
-    * {Resource2}
-    * ...
+  * {Resource1}
+  * {Resource2}
+  * ...


### PR DESCRIPTION
This fix just corrects the markdown best practice rule violations in the DSCResource.Template/Readme.md.

The most significant change is that the AppVeyor build badge is moved to below the top level header line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/224)
<!-- Reviewable:end -->
