### PR TITLE
Replace TestEnvironment.WorkingFolder with TestDrive

### DIFF
--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -46,8 +46,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile and apply the MOF without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder `
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }


### PR DESCRIPTION
Removing TestEnvironment.WorkingFolder from the integration test template since this property no longer exists.

It has been replaced with Pester's built-in $TestDrive.

@mbreakey3 Please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/230)
<!-- Reviewable:end -->
