### PR TITLE
Adding powershell code highlighting to example for markdown

### DIFF
--- a/DscResource.DocumentationHelper/Modules/WikiPages.psm1
+++ b/DscResource.DocumentationHelper/Modules/WikiPages.psm1
@@ -94,12 +94,14 @@ function Write-DscResourceWikiSite {
                     $helpEnd = $exampleContent.IndexOf("#>") + 2
                     $help = $exampleContent.Substring($helpStart, $helpEnd - $helpStart)
                     $helpOriginal = $help
+                    $help += [Environment]::NewLine + '````powershell'
                     $help = $help.Replace("    ", "")
                     $exampleContent = $exampleContent -replace $helpOriginal, $help
                     $exampleContent = $exampleContent -replace "<#"
                     $exampleContent = $exampleContent -replace "#>"
                     $exampleContent = $exampleContent.Replace(".EXAMPLE", `
                                                             "***Example $exampleCount***`n")
+                    $exampleContent += [Environment]::NewLine + '````'
 
                     $output += $exampleContent 
                     $output += [Environment]::NewLine

--- a/DscResource.DocumentationHelper/Modules/WikiPages.psm1
+++ b/DscResource.DocumentationHelper/Modules/WikiPages.psm1
@@ -78,7 +78,6 @@ function Write-DscResourceWikiSite {
             $descriptionContent = Get-Content -Path $descriptionPath -Raw
             $output += [Environment]::NewLine + $descriptionContent + [Environment]::NewLine
 
-
             $exampleSearchPath = "\Examples\Resources\$($result.FriendlyName)\*.ps1"
             $examplesPath = (Join-Path -Path $ModulePath -ChildPath $exampleSearchPath)
             $exampleFiles = Get-ChildItem -Path $examplesPath
@@ -101,7 +100,7 @@ function Write-DscResourceWikiSite {
                     $exampleContent = $exampleContent -replace "#>"
                     $exampleContent = $exampleContent.Replace(".EXAMPLE", `
                                                             "***Example $exampleCount***`n")
-                    $exampleContent += [Environment]::NewLine + '````'
+                    $exampleContent += '````'
 
                     $output += $exampleContent 
                     $output += [Environment]::NewLine

--- a/DscResource.DocumentationHelper/WikiExample.md
+++ b/DscResource.DocumentationHelper/WikiExample.md
@@ -34,8 +34,8 @@ will be in a later release
 
 This example creates a site collection with the provided details
 
-
-    Configuration Example 
+````powershell
+    Configuration Example
     {
         param(
             [Parameter(Mandatory = $true)]
@@ -56,5 +56,5 @@ This example creates a site collection with the provided details
             }
         }
     }
-
+````
 


### PR DESCRIPTION
This will add code highlighting to the examples.  This makes the wiki formatting nicer to look at.  Also fixes a formatting issue I was having with the documentation where git hub couldn't figure out I was formatting code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/238)
<!-- Reviewable:end -->
