### PR TITLE
StyleGuideline.md: Clarified that UTF-8 does not mean UTF-8 with BOM - Fixes #285

### DIFF
--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -53,7 +53,7 @@ GitHub will still render the sentences as a single paragraph, but the readabilit
 
 ### Correct File Encoding
 
-Make sure all files are encoded using UTF-8, except mof files which should be encoded using ASCII.
+Make sure all files are encoded using UTF-8 (not UTF-8 with BOM), except mof files which should be encoded using ASCII.
 You can use ```ConvertTo-UTF8``` and ```ConvertTo-ASCII``` to convert a file to UTF-8 or ASCII.
 
 ### Descriptive Names


### PR DESCRIPTION
- Changes to StyleGuideline.md
  - Clarified that UTF-8 does not mean UTF-8 with BOM (issue #285).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/286)
<!-- Reviewable:end -->
