### PR TITLE
Fix git clone issues for DscResource.Tests - Fixes #287

### DIFF
--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -166,7 +166,7 @@ $superLongVariableName = Get-MySuperLongVariablePlease @getMySuperLongVariablePl
 ### Correct Format for Arrays
 
 Arrays should be written in the following format.
-Arrays should be writen on one line unless they exceed the line character limit.
+Arrays should be written on one line unless they exceed the line character limit.
 There should be a single space between each element in the array.
 Hashtables should not be declared inside an array.
 
@@ -234,7 +234,7 @@ $hashtable = @{
 ### Correct Format for Comments
 
 There should not be any commented-out code in checked-in files.
-The first letter of the comment should be captialized.
+The first letter of the comment should be capitalized.
 
 Single line comments should be on their own line and start with a single pound-sign followed by a single space.
 The comment should be indented the same amount as the following line of code.
@@ -805,7 +805,7 @@ function New-Event
 
 ### Parameter Block at Top of Function
 
-There must be a parameter block decalred for every function.
+There must be a parameter block declared for every function.
 The parameter block must be at the top of the function and not declared next to the function name.
 Functions with no parameters should still display an empty parameter block.
 

--- a/Tests.Template/changelist.md
+++ b/Tests.Template/changelist.md
@@ -8,6 +8,9 @@ When the templates are used to create or update tests in a DSC Resource the vers
 * First release including version number.
 
 ## integration_template.ps1
+### Version 1.1.2
+* Removed backslashes from git clone command to improve compatibility with unusual file paths
+
 ### Version 1.1.1
 * Convert Invoke-Expression to '&' to improve readability.
 
@@ -18,6 +21,9 @@ When the templates are used to create or update tests in a DSC Resource the vers
 * First release including version number.
 
 ## unit_template.ps1
+### Version 1.2.1
+* Removed backslashes from git clone command to improve compatibility with unusual file paths
+
 ### Version 1.1.0
 * Getting rid of git-dependency.
 

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -3,9 +3,9 @@
    Template for creating DSC Resource Integration Tests
 .DESCRIPTION
    To Use:
-     1. Copy to \Tests\Integration\ folder and rename <ResourceName>.Integration.tests.ps1 (e.g. MSFT_xNeworking.Integration.tests.ps1)
+     1. Copy to \Tests\Integration\ folder and rename <ResourceName>.Integration.tests.ps1 (e.g. MSFT_xNetworking.Integration.tests.ps1)
      2. Customize TODO sections.
-     3. Create test DSC Configuration file <ResourceName>.config.ps1 (e.g. MSFT_xNeworking.config.ps1) from integration_config_template.ps1 file.
+     3. Create test DSC Configuration file <ResourceName>.config.ps1 (e.g. MSFT_xNetworking.config.ps1) from integration_config_template.ps1 file.
 
 .NOTES
    Code in HEADER, FOOTER and DEFAULT TEST regions are standard and may be moved into
@@ -47,13 +47,14 @@ try
         It 'Should compile and apply the MOF without throwing' {
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+
                 Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should Not Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
         }
         #endregion
 

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -22,7 +22,7 @@ $script:DSCResourceName    = '<ResourceName>' # Example MSFT_xFirewall
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -54,7 +54,9 @@ try
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            {
+				Get-DscConfiguration -Verbose -ErrorAction Stop 
+			} | Should Not Throw
         }
         #endregion
 

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -5,7 +5,7 @@
    To Use:
      1. Copy to \Tests\Integration\ folder and rename <ResourceName>.Integration.tests.ps1 (e.g. MSFT_xNeworking.Integration.tests.ps1)
      2. Customize TODO sections.
-     3. Create test DSC Configurtion file <ResourceName>.config.ps1 (e.g. MSFT_xNeworking.config.ps1) from integration_config_template.ps1 file.
+     3. Create test DSC Configuration file <ResourceName>.config.ps1 (e.g. MSFT_xNeworking.config.ps1) from integration_config_template.ps1 file.
 
 .NOTES
    Code in HEADER, FOOTER and DEFAULT TEST regions are standard and may be moved into
@@ -17,12 +17,12 @@ $script:DSCModuleName      = '<ModuleName>' # Example xNetworking
 $script:DSCResourceName    = '<ResourceName>' # Example MSFT_xFirewall
 
 #region HEADER
-# Integration Test Template Version: 1.1.1
+# Integration Test Template Version: 1.1.2
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force

--- a/Tests.Template/unit_template.ps1
+++ b/Tests.Template/unit_template.ps1
@@ -16,12 +16,12 @@
 
 #region HEADER
 
-# Unit Test Template Version: 1.2.0
+# Unit Test Template Version: 1.2.1
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force

--- a/Tests.Template/unit_template.ps1
+++ b/Tests.Template/unit_template.ps1
@@ -21,7 +21,7 @@ $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force


### PR DESCRIPTION
Remove the trailing backslash from the git clone within the DSC Testing templates.  This caused an issue when the file path had an apostrophe in it.  See Issue #287

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/299)
<!-- Reviewable:end -->
