### PR TITLE
Capitalization guideline - Fixes #300

### DIFF
--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -42,7 +42,7 @@ In order to provide clean and consistent code, please follow the style guideline
 - [Best Practices](#best-practices)
   - [Named Parameters Instead of Positional Parameters](#named-parameters-instead-of-positional-parameters)
   - [No Cmdlet Aliases](#no-cmdlet-aliases)
-  - [Capitalized cmdlets, Function Names and Pester Assertions](#Capitalized-cmdlets,-Function-Names-and-Pester-Assertions)
+  - [Capitalized cmdlets, Function Names and Pester Assertions](#capitalized-cmdlets-function-names-and-pester-assertions)
   - [No Backslash in Paths](#no-backslash-in-paths)
 
 ## Markdown Files

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -679,7 +679,7 @@ function Get-TargetResource
 
 ### Function Names Use Pascal Case
 
-Function names must use PascalCase.
+Function names must use PascalCase.  This means that each concatenating word is capitalized.  
 
 **Bad:**
 
@@ -989,7 +989,7 @@ function Write-Text
 
 ### Parameter Names Use Pascal Case
 
-All parameters must use PascalCase.
+All parameters must use PascalCase.  This means that each concatenating word is capitalized.  
 
 **Bad:**
 
@@ -1286,9 +1286,9 @@ ls -File $root -Recurse | ? { @('.gitignore', '.mof') -contains $_.Extension }
 Get-ChildItem -File $root -Recurse | Where-Object { @('.gitignore', '.mof') -contains $_.Extension }
 ```
 
-### Capitalized cmdlets, Function Names and Pester Assertions
+### Capitalized Pester Assertions
 
-PowerShell cmdlets, Functions and Pester assertions should all start with capital letters.  This makes code easier to read, especially when there are multiple nouns in the command name.  
+Pester assertions should all start with capital letters.  This makes code easier to read.
 
 **Bad:**
 
@@ -1298,24 +1298,12 @@ it 'Should return something' {
 }
 ```
 
-**Bad:**
-
-```powershell
-new-function -name $newfunctionparameter
-```
-
 **Good:**
 
 ```powershell
 It 'Should return something' {
     Get-TargetResource @testParameters | Should Be 'something'
 }
-```
-
-**Good:**
-
-```powershell
-New-Function -Name $newFunctionParameter
 ```
 
 ### No Backslash in Paths

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -1285,6 +1285,38 @@ ls -File $root -Recurse | ? { @('.gitignore', '.mof') -contains $_.Extension }
 Get-ChildItem -File $root -Recurse | Where-Object { @('.gitignore', '.mof') -contains $_.Extension }
 ```
 
+### Capitalised cmdlets, Function Names and Pester Assertions
+
+PowerShell cmdlets, Functions and Pester assertions should all start with capital letters.  This makes code easier to read, especially when there are multiple nouns in the command name.  
+
+**Bad:**
+
+```powershell
+it 'Should return something' {
+    get-targetresource @testParameters | should be 'something'
+}
+```
+
+**Bad:**
+
+```powershell
+new-function -name $params
+```
+
+**Good:**
+
+```powershell
+It 'Should return something' {
+    Get-TargetResource @testParameters | Should Be 'something'
+}
+```
+
+**Good:**
+
+```powershell
+New-Function -Name $params
+```
+
 ### No Backslash in Paths
 
 To support the possibility of cross-platform use in the future, backslashes should not be used within a path. Instead `Join-Path` and `Split-Path` should be used to build a path.

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -42,6 +42,7 @@ In order to provide clean and consistent code, please follow the style guideline
 - [Best Practices](#best-practices)
   - [Named Parameters Instead of Positional Parameters](#named-parameters-instead-of-positional-parameters)
   - [No Cmdlet Aliases](#no-cmdlet-aliases)
+  - [Capitalized cmdlets, Function Names and Pester Assertions](#Capitalized-cmdlets-Function-Names-and-Pester-Assertions)
   - [No Backslash in Paths](#no-backslash-in-paths)
 
 ## Markdown Files
@@ -1285,7 +1286,7 @@ ls -File $root -Recurse | ? { @('.gitignore', '.mof') -contains $_.Extension }
 Get-ChildItem -File $root -Recurse | Where-Object { @('.gitignore', '.mof') -contains $_.Extension }
 ```
 
-### Capitalised cmdlets, Function Names and Pester Assertions
+### Capitalized cmdlets, Function Names and Pester Assertions
 
 PowerShell cmdlets, Functions and Pester assertions should all start with capital letters.  This makes code easier to read, especially when there are multiple nouns in the command name.  
 

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -1301,7 +1301,7 @@ it 'Should return something' {
 **Bad:**
 
 ```powershell
-new-function -name $params
+new-function -name $newfunctionparameter
 ```
 
 **Good:**
@@ -1315,7 +1315,7 @@ It 'Should return something' {
 **Good:**
 
 ```powershell
-New-Function -Name $params
+New-Function -Name $newFunctionParameter
 ```
 
 ### No Backslash in Paths

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -42,7 +42,7 @@ In order to provide clean and consistent code, please follow the style guideline
 - [Best Practices](#best-practices)
   - [Named Parameters Instead of Positional Parameters](#named-parameters-instead-of-positional-parameters)
   - [No Cmdlet Aliases](#no-cmdlet-aliases)
-  - [Capitalized cmdlets, Function Names and Pester Assertions](#Capitalized-cmdlets-Function-Names-and-Pester-Assertions)
+  - [Capitalized cmdlets, Function Names and Pester Assertions](#Capitalized-cmdlets,-Function-Names-and-Pester-Assertions)
   - [No Backslash in Paths](#no-backslash-in-paths)
 
 ## Markdown Files

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -42,7 +42,7 @@ In order to provide clean and consistent code, please follow the style guideline
 - [Best Practices](#best-practices)
   - [Named Parameters Instead of Positional Parameters](#named-parameters-instead-of-positional-parameters)
   - [No Cmdlet Aliases](#no-cmdlet-aliases)
-  - [Capitalized cmdlets, Function Names and Pester Assertions](#capitalized-cmdlets-function-names-and-pester-assertions)
+  - [Capitalized Pester Assertions](#capitalized-pester-assertions)
   - [No Backslash in Paths](#no-backslash-in-paths)
 
 ## Markdown Files
@@ -679,7 +679,7 @@ function Get-TargetResource
 
 ### Function Names Use Pascal Case
 
-Function names must use PascalCase.  This means that each concatenating word is capitalized.  
+Function names must use PascalCase.  This means that each concatenated word is capitalized.  
 
 **Bad:**
 
@@ -989,7 +989,7 @@ function Write-Text
 
 ### Parameter Names Use Pascal Case
 
-All parameters must use PascalCase.  This means that each concatenating word is capitalized.  
+All parameters must use PascalCase.  This means that each concatenated word is capitalized.  
 
 **Bad:**
 


### PR DESCRIPTION
Creates a new capitalisation guideline to remind contributors that Functions, cmdlets and Pester assertions should be capitalised for readability.  Fixes issue #300

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/304)
<!-- Reviewable:end -->
