### PR TITLE
Add ErrorAction Stop to cmdlet Start-DscConfiguration - Fixes #321

### DIFF
--- a/Tests.Template/changelist.md
+++ b/Tests.Template/changelist.md
@@ -8,8 +8,12 @@ When the templates are used to create or update tests in a DSC Resource the vers
 * First release including version number.
 
 ## integration_template.ps1
+### Version 1.1.3
+* Now `-ErrorAction Stop` is used for the cmdlet Start-DscConfiguration so
+  that all errors throw an error making the tests fail.
+
 ### Version 1.1.2
-* Removed backslashes from git clone command to improve compatibility with unusual file paths
+* Removed backslashes from git clone command to improve compatibility with unusual file paths.
 
 ### Version 1.1.1
 * Convert Invoke-Expression to '&' to improve readability.
@@ -22,7 +26,7 @@ When the templates are used to create or update tests in a DSC Resource the vers
 
 ## unit_template.ps1
 ### Version 1.2.1
-* Removed backslashes from git clone command to improve compatibility with unusual file paths
+* Removed backslashes from git clone command to improve compatibility with unusual file paths.
 
 ### Version 1.1.0
 * Getting rid of git-dependency.

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -17,7 +17,7 @@ $script:DSCModuleName      = '<ModuleName>' # Example xNetworking
 $script:DSCResourceName    = '<ResourceName>' # Example MSFT_xFirewall
 
 #region HEADER
-# Integration Test Template Version: 1.1.2
+# Integration Test Template Version: 1.1.3
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -13,16 +13,16 @@
 #>
 
 # TODO: Customize these parameters...
-$script:DSCModuleName      = '<ModuleName>' # Example xNetworking
-$script:DSCResourceName    = '<ResourceName>' # Example MSFT_xFirewall
+$script:DSCModuleName = '<ModuleName>' # Example xNetworking
+$script:DSCResourceName = '<ResourceName>' # Example MSFT_xFirewall
 
 #region HEADER
 # Integration Test Template Version: 1.1.3
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
@@ -49,12 +49,12 @@ try
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
 
                 $startDscConfigurationParameters = @{
-                    Path = $TestDrive
+                    Path         = $TestDrive
                     ComputerName = 'localhost'
-                    Wait = $true
-                    Verbose = $true
-                    Force = $true
-                    ErrorAction = 'Stop'
+                    Wait         = $true
+                    Verbose      = $true
+                    Force        = $true
+                    ErrorAction  = 'Stop'
                 }
 
                 Start-DscConfiguration @startDscConfigurationParameters
@@ -63,8 +63,8 @@ try
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
             {
-				Get-DscConfiguration -Verbose -ErrorAction Stop
-			} | Should Not Throw
+                Get-DscConfiguration -Verbose -ErrorAction Stop
+            } | Should Not Throw
         }
         #endregion
 

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -48,14 +48,22 @@ try
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
 
-                Start-DscConfiguration -Path $TestDrive `
-                    -ComputerName localhost -Wait -Verbose -Force
+                $startDscConfigurationParameters = @{
+                    Path = $TestDrive
+                    ComputerName = 'localhost'
+                    Wait = $true
+                    Verbose = $true
+                    Force = $true
+                    ErrorAction = 'Stop'
+                }
+
+                Start-DscConfiguration @startDscConfigurationParameters
             } | Should Not Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
             {
-				Get-DscConfiguration -Verbose -ErrorAction Stop 
+				Get-DscConfiguration -Verbose -ErrorAction Stop
 			} | Should Not Throw
         }
         #endregion


### PR DESCRIPTION
- Changes to integration test template
  - Added `-ErrorAction 'Stop'` to cmdlet `Start-DscConfiguration`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/322)
<!-- Reviewable:end -->
