### PR TITLE
Add error handling logic for Start-DscConfiguration in integration test template - Fixes #354

### DIFF
--- a/Tests.Template/changelist.md
+++ b/Tests.Template/changelist.md
@@ -9,6 +9,11 @@ When the templates are used to create or update tests in a DSC Resource the vers
 
 ## integration_template.ps1
 
+
+### Version 1.2.1
+
+* Add error handling logic for Start-DscConfiguration  (Fixes #354)
+
 ### Version 1.2.0
 * Update Pester syntax to v4
 * Now `-ErrorAction Stop` is used for the cmdlet Start-DscConfiguration so

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -31,7 +31,11 @@ $TestEnvironment = Initialize-TestEnvironment `
     -DSCResourceName $script:DSCResourceName `
     -TestType Integration
 
-$integrationErrorMessagePrefix = 'INTEGRATION ERROR MESSAGE:'
+<#
+    If the integration test throws an error, this is the prefix that will be added
+    to the message before writing out the verbose message to the console.
+#>
+$script:integrationErrorMessagePrefix = 'INTEGRATION ERROR MESSAGE:'
 #endregion
 
 # TODO: Other Init Code Goes Here...
@@ -64,7 +68,7 @@ try
                 }
                 catch
                 {
-                    Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
+                    Write-Verbose -Message ('{0} {1}' -f $script:integrationErrorMessagePrefix, $_) -Verbose
                     throw $_
                 }
             } | Should -Not -Throw

--- a/Tests.Template/integration_template.ps1
+++ b/Tests.Template/integration_template.ps1
@@ -17,7 +17,7 @@ $script:DSCModuleName = '<ModuleName>' # Example xNetworking
 $script:DSCResourceName = '<ResourceName>' # Example MSFT_xFirewall
 
 #region HEADER
-# Integration Test Template Version: 1.2.0
+# Integration Test Template Version: 1.2.1
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
@@ -31,6 +31,7 @@ $TestEnvironment = Initialize-TestEnvironment `
     -DSCResourceName $script:DSCResourceName `
     -TestType Integration
 
+$integrationErrorMessagePrefix = 'INTEGRATION ERROR MESSAGE:'
 #endregion
 
 # TODO: Other Init Code Goes Here...
@@ -57,7 +58,15 @@ try
                     ErrorAction  = 'Stop'
                 }
 
-                Start-DscConfiguration @startDscConfigurationParameters
+                try
+                {
+                    Start-DscConfiguration @startDscConfigurationParameters
+                }
+                catch
+                {
+                    Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
+                    throw $_
+                }
             } | Should -Not -Throw
         }
 


### PR DESCRIPTION
- Changes to Integration Test template
  - Add error handling logic for Start-DscConfiguration (Fixes #354)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/355)
<!-- Reviewable:end -->
