### PR TITLE
Updated xTimeZone maintainer to be DEPRECATED - Fixed #375

### DIFF
--- a/Maintainers.md
+++ b/Maintainers.md
@@ -96,7 +96,7 @@ and Mariah Breakey ([@mbreakey3](https://github.com/mbreakey3)).
 | xSmbShare | --- |
 | xSqlPs | --- |
 | xSystemSecurity | --- |
-| xTimeZone | Daniel Scott-Raynsford ([@PlagueHO](https://github.com/PlagueHO)) |
+| xTimeZone | DEPRECATED - Migrated to [ComputerManagementDsc](https://github.com/PowerShell/ComputerManagementDsc) |
 | xWebAdministration | Tyson Hayes ([@tysonjhayes](https://github.com/tysonjhayes)) |
 | xWebDeploy | --- |
 | xWindowsEventForwarding | --- |


### PR DESCRIPTION
The xTimeZone maintainer is updated to a DEPRECATED message.

@johlju - I wasn't actually sure what to do in this case as we haven't done this before as far as I can see. So let me know if you think there is a more appropriate way?

Fixes #375 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/376)
<!-- Reviewable:end -->
