### PR TITLE
Update Maintainers.md

### DIFF
--- a/Maintainers.md
+++ b/Maintainers.md
@@ -75,7 +75,7 @@ and Mariah Breakey ([@mbreakey3](https://github.com/mbreakey3)).
 | xExchange | Mike Hendrickson ([@mhendric](https://github.com/mhendric)) |
 | xFailOverCluster | Johan Ljunggren ([@johlju](https://github.com/johlju)) |
 | xFirefox | --- |
-| xHyper-V | Brian Farnhill ([@BrianFarnhill](https://github.com/BrianFarnhill)) |
+| xHyper-V | --- |
 | xInternetExplorerHomePage | --- |
 | xJea | --- |
 | xMySql | --- |


### PR DESCRIPTION
- As per request, we are removing Brian Farnhill as maintainer for xHyper-V

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/422)
<!-- Reviewable:end -->
