### PR TITLE
Deprecate xSmbShare

### DIFF
--- a/Maintainers.md
+++ b/Maintainers.md
@@ -94,8 +94,7 @@ and Mariah Breakey ([@mbreakey3](https://github.com/mbreakey3)).
 | [xSCSMA](https://github.com/PowerShell/xSCSMA) | --- |
 | [xSCSPF](https://github.com/PowerShell/xSCSPF) | --- |
 | [xSCSR](https://github.com/PowerShell/xSCSR) | --- |
-| [xSCVMM](https://github.com/PowerShell/xSCVMM) | Jan-Hendrik Peters ([@nyanhp](https://github.com/nyanhp)) |
-| [xSmbShare](https://github.com/PowerShell/xSmbShare) | Johan Ljunggren ([@johlju](https://github.com/johlju)) |
+| xSmbShare | DEPRECATED - Migrated to [ComputerManagementDsc](https://github.com/PowerShell/ComputerManagementDsc) |
 | xSqlPs | DEPRECATED - Replaced by [SqlServerDsc](https://github.com/PowerShell/SqlServerDsc) |
 | [xSystemSecurity](https://github.com/PowerShell/xSystemSecurity) | --- |
 | xTimeZone | DEPRECATED - Migrated to [ComputerManagementDsc](https://github.com/PowerShell/ComputerManagementDsc) |

--- a/Maintainers.md
+++ b/Maintainers.md
@@ -94,6 +94,7 @@ and Mariah Breakey ([@mbreakey3](https://github.com/mbreakey3)).
 | [xSCSMA](https://github.com/PowerShell/xSCSMA) | --- |
 | [xSCSPF](https://github.com/PowerShell/xSCSPF) | --- |
 | [xSCSR](https://github.com/PowerShell/xSCSR) | --- |
+| [xSCVMM](https://github.com/PowerShell/xSCVMM) | Jan-Hendrik Peters ([@nyanhp](https://github.com/nyanhp)) |
 | xSmbShare | DEPRECATED - Migrated to [ComputerManagementDsc](https://github.com/PowerShell/ComputerManagementDsc) |
 | xSqlPs | DEPRECATED - Replaced by [SqlServerDsc](https://github.com/PowerShell/SqlServerDsc) |
 | [xSystemSecurity](https://github.com/PowerShell/xSystemSecurity) | --- |


### PR DESCRIPTION
#### Pull Request (PR) description
Deprecating this resource module xSmbShare.

*This PR should only be merged once the PR PowerShell/ComputerManagementDsc#211, and the PR https://github.com/PowerShell/xSmbShare/pull/31 is merged.*

#### This Pull Request (PR) fixes the following issues
As discussed in issue PowerShell/DscResources#374.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] This PR changes documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/499)
<!-- Reviewable:end -->