### PR TITLE
Clean up Markdown Rule Violations and change Chat Icons - Fixes #512

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+    "default": true,
+    "MD029": {
+        "style": "one"
+    },
+    "MD013": true,
+    "MD024": false,
+    "MD034": false,
+    "no-hard-tabs": true
+}

--- a/Automation.md
+++ b/Automation.md
@@ -4,6 +4,11 @@ Some areas and workflows of the DSC Resource Kit are automated, and future
 automation will cover other areas. This document has both information around
 present automations, and potential future automations.
 
+> Important note: the Waffle Board is being deprecated in favor of using a
+> [GitHub Project board](https://github.com/orgs/PowerShell/projects/1).
+> The documentation in this document is yet to be updated to reflect this
+> new board.
+
 ## Table of Contents
 
 - [Labels](#labels)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,185 +1,254 @@
 # Contributing to the DSC Resource Kit
 
-Welcome to the DSC Resource Kit! We're thrilled that you'd like to contribute! Our community is essential to creating and maintaining all the DSC Resources.
+Welcome to the DSC Resource Kit! We're thrilled that you'd like to contribute!
+Our community is essential to creating and maintaining all the DSC Resources.
 
 There are a few different ways you can contribute:
 
-* [Submit an issue](#submitting-an-issue)
-* [Fix an issue](#fixing-an-issue)
-* [Write documentation](#writing-documentation)
-* [Review pull requests](#reviewing-pull-requests)
+- [Submit an issue](#submitting-an-issue)
+- [Fix an issue](#fixing-an-issue)
+- [Write documentation](#writing-documentation)
+- [Review pull requests](#reviewing-pull-requests)
 
-If you're just starting out with GitHub, start by reading our [guide to getting started with GitHub](GettingStartedWithGitHub.md).
+If you're just starting out with GitHub, start by reading our
+[guide to getting started with GitHub](GettingStartedWithGitHub.md).
 
-If you have any questions or concerns, feel free to reach out to [@kwirkykat](https://github.com/kwirkykat) or [@mbreakey3](https://github.com/mbreakey3) for help.
+If you have any questions or concerns, feel free to reach out to
+[@kwirkykat](https://github.com/kwirkykat) or [@mbreakey3](https://github.com/mbreakey3)
+for help.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
+additional questions or comments.
 
 ## Submitting an Issue
+
 Submitting an issue to the DSC Resource Kit is easy!
 
 Here are the steps:
 
 1. Find the correct repository to submit your issue to.
-2. Make sure the issue is not open already.
-3. Open a new issue.
-4. Fill in the issue title.
-5. Fill in the issue description.
-6. Submit the issue.
+1. Make sure the issue is not open already.
+1. Open a new issue.
+1. Fill in the issue title.
+1. Fill in the issue description.
+1. Submit the issue.
 
 ### Find the Correct Repository
+
 | Issue Topic | Where to Submit |
 |-------------|-----------------|
-| <ul><li> DSC Resource Kit overall </li><li> Issues that span multiple resource modules </li><li> DSC Resource Kit processes </li></ul> | DscResources (this repository!) |
+| <ul><li> DSC Resource Kit overall </li><li> Issues that span multiple resourcemodules </li><li> DSC Resource Kit processes </li></ul> | DscResources (this repository!) |
 | <ul><li> Common tests </li><li> Meta-fixers </li></ul> | [DscResource.Tests](https://github.com/PowerShell/DscResource.Tests)
 | <ul><li> Bugs, feature requests, enhancements to a specific resource </li><li> Resource proposals </li></ul> | The repository of the resource module that contains/should contain the resource. |
 | <ul><li> Bugs, feature requests, enhancements that span multiple resources within one resource module </li></ul> | The repository of that resource module |
 
 You can access a resource module repository with the following URL:
-```
+
+```plaintext
 https://github.com/PowerShell/<name of resource module>
 ```
+
 For example, to get to the xCertificate module repository, the URL is:
-```
+
+```plaintext
 https://github.com/PowerShell/xCertificate
 ```
 
-All DSC resource modules are also listed as submodules of this repository under the [xDscResources](xDscResources) and [DscResources](dscresources) folders.
+All DSC resource modules are also listed as submodules of this repository under
+the [xDscResources](xDscResources) and [DscResources](dscresources) folders.
 
 ### Open an Issue
+
 Once you are in the correct repository to submit your issue, go to the Issues tab.
 ![GitHubIssuesTab](Images/GitHubIssuesTab.png)
 
 **Ensure that the issue you are about to file is not already open.**
-If someone has already opened a similar issue, please leave a comment or add a GitHub reaction to the top comment to **express your interest**. You can also offer help and use the issue to coordinate your efforts in fixing the issue.
+If someone has already opened a similar issue, please leave a comment or add a
+GitHub reaction to the top comment to **express your interest**. You can also
+offer help and use the issue to coordinate your efforts in fixing the issue.
 
-If you cannot find an issue that matches the one you are about to file, click the New Issue button on the right.
+If you cannot find an issue that matches the one you are about to file, click
+the New Issue button on the right.
 ![GitHubNewIssueButton](Images/GitHubNewIssueButton.png)
 
 A new, blank issue should open up.
 ![GitHubBlankIssue](Images/GitHubBlankIssue.PNG)
 
 ### Fill in Issue Title
+
 The issue title should be a brief summary of your issue in one sentence.
-If it pertains to only one specific resource please prefix the issue title with the resource name followed by a colon.
+If it pertains to only one specific resource please prefix the issue title with
+the resource name followed by a colon.
 For example:
 ![GitHubSpecificResourceIssueTitle](Images/GitHubSpecificResourceIssueTitle.PNG)
 
-If you would like to submit an issue that would include a breaking change, please also refer to our [Breaking Changes](#breaking-changes) section below.
+If you would like to submit an issue that would include a breaking change, please
+also refer to our [Breaking Changes](#breaking-changes) section below.
 
 ### Fill in Issue Description
-The issue description should contain a **detailed** report of the issue you are submitting.
-If you are submitting a bug, please include any error messages or stack traces caused by the problem.
 
-Please reference any related issues or pull requests by a pound sign followed by the issue or pull request number (e.g. #11, #72). GitHub will automatically link the number to the corresponding issue or pull request. You can also link to pull requests and issues in other repositories by including the repository owner and name before the issue number.
+The issue description should contain a **detailed** report of the issue you are submitting.
+If you are submitting a bug, please include any error messages or stack traces
+caused by the problem.
+
+Please reference any related issues or pull requests by a pound sign followed by
+the issue or pull request number (e.g. #11, #72). GitHub will automatically link
+the number to the corresponding issue or pull request. You can also link to pull
+requests and issues in other repositories by including the repository owner and
+name before the issue number.
+
 Like this:
-```
+
+```plaintext
 <owner name>/<repository name>#<number of PR/issue>
 ```
-So to link to issue #160 in the xPSDesiredStateConfiguration repository which is owned by PowerShell:
-```
+
+So to link to issue #160 in the xPSDesiredStateConfiguration repository which is
+owned by PowerShell:
+
+```plaintext
 PowerShell/xPSDesiredStateConfiguration#160
 ```
 
-Please also tag any GitHub users you would like to notice this issue. You can tag someone on GitHub with the @ symbol followed by their username.(e.g. @kwirkykat)
+Please also tag any GitHub users you would like to notice this issue. You can
+tag someone on GitHub with the @ symbol followed by their username.(e.g. @kwirkykat)
 
 ### Submit an Issue
-Once you have filled out the issue title and description, click the submit button at the bottom of the issue.
+
+Once you have filled out the issue title and description, click the submit button
+at the bottom of the issue.
 ![GitHubIssueSubmitButton](Images/GitHubIssueSubmitButton.png)
 
 ## Fixing an Issue
+
 Here's the general process of fixing an issue in the DSC Resource Kit:
+
 1. Pick out the issue you'd like to work on.
-2. Create a fork of the repository that contains the issue.
-3. Clone your fork to your machine.
-4. Create a working branch where you can store your updates to the code.
-5. Make changes in your working branch to solve the issue.
-6. Write tests to ensure that the issue is fixed.
-7. Update the 'Unreleased' section of the module's release notes to include your changes.
-8. Submit a pull request to the dev branch of the official repository for review.
-9. Make sure all tests are passing in AppVeyor for your pull request.
-10. Make sure your code does not contain merge conflicts.
-11. Address any comments brought up by the reviewer.
+1. Create a fork of the repository that contains the issue.
+1. Clone your fork to your machine.
+1. Create a working branch where you can store your updates to the code.
+1. Make changes in your working branch to solve the issue.
+1. Write tests to ensure that the issue is fixed.
+1. Update the 'Unreleased' section of the module's release notes to include your
+  changes.
+1. Submit a pull request to the dev branch of the official repository for review.
+1. Make sure all tests are passing in AppVeyor for your pull request.
+1. Make sure your code does not contain merge conflicts.
+1. Address any comments brought up by the reviewer.
 
 ### Pick an Issue
-Issues that are currently up-for-grabs are tagged with the ```help wanted``` label.
-You can see all the issues tagged with ```help wanted``` across all the modules in the DSC Resource Kit in the Help Wanted column on our [dashboard](https://waffle.io/powershell/dscresources/join).
 
-If you find an issue that you want to work on, but it does not have the ```help wanted``` label, make sure to read through the issue and ask if you can start working on it.
+Issues that are currently up-for-grabs are tagged with the ```help wanted``` label.
+You can see all the issues tagged with ```help wanted``` across all the modules
+in the DSC Resource Kit in the Help Wanted column on our [dashboard](https://waffle.io/powershell/dscresources/join).
+
+If you find an issue that you want to work on, but it does not have the
+```help wanted``` label, make sure to read through the issue and ask if you can
+start working on it.
 
 ### Fork a Respository
+
 A 'fork' on GitHub is your own personal copy of a repository.
 GitHub's guide to forking a repository is available [here](https://help.github.com/articles/fork-a-repo/).
-You will need a fork to contribute to any of the repositories in the DSC Resource Kit since only the maintainers have the ability to push to the official repositories.
+You will need a fork to contribute to any of the repositories in the DSC Resource
+Kit since only the maintainers have the ability to push to the official repositories.
 
 Once you have created your fork, you can easily access it via the URL:
-```
+
+```plaintext
 https://github.com/<your GitHub username>/<module name>
 ```
 
 ### Clone your Fork
+
 You will want to clone your fork so that you can edit code locally on your machine.
 GitHub's guide to cloning is available [here](https://help.github.com/articles/cloning-a-repository/).
 
 ### Create a Working Branch
-We use a [git flow](http://nvie.com/posts/a-successful-git-branching-model/) model in our official repositories.
+
+We use a [git flow](http://nvie.com/posts/a-successful-git-branching-model/) model
+in our official repositories.
 
 Your fork is your personal territory.
-You may set it up however best suits your workflow, but we recommend that you set up a working branch separate from the default dev branch.
-Creating a working branch separate from the default dev branch will allow you to create other working branches off of dev later while your original working branch is still open for code reviews.
-Limiting your current working branch to a single issue will also both streamline the code review and reduce the possibility of merge conflicts.
+You may set it up however best suits your workflow, but we recommend that you set
+up a working branch separate from the default dev branch.
+Creating a working branch separate from the default dev branch will allow you to
+create other working branches off of dev later while your original working branch
+is still open for code reviews.
+Limiting your current working branch to a single issue will also both streamline
+the code review and reduce the possibility of merge conflicts.
 
 The Git guide to branching is available [here](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging).
 
 ### Make Code Changes
-When writing code for any of the modules in the DSC Resource Kit, please follow the DSC Resource Kit [Style Guidelines](StyleGuidelines.md) and [Best Practices](BestPractices.md).
-These guidelines are specific to the DSC Resource Kit and may not always reflect the same PowerShell style as other projects.
-Code reviewers will expect you to follow these guidelines and may ask you to change your code for consistency.
 
-If you need help committing and pushing your code to your fork, please refer to our [guide to getting started with GitHub](GettingStartedWithGitHub.md).
+When writing code for any of the modules in the DSC Resource Kit, please follow
+the DSC Resource Kit [Style Guidelines](StyleGuidelines.md) and [Best Practices](BestPractices.md).
+These guidelines are specific to the DSC Resource Kit and may not always reflect
+the same PowerShell style as other projects.
+Code reviewers will expect you to follow these guidelines and may ask you to change
+your code for consistency.
 
-Pay attention to any new code merged into the dev branch of the official repository. If this occurs, you will need to pick-up these changes in your fork using the rebase instructions in our [guide to getting started with GitHub](GettingStartedWithGitHub.md).
+If you need help committing and pushing your code to your fork, please refer to our
+[guide to getting started with GitHub](GettingStartedWithGitHub.md).
 
-If you are making a breaking change, please make sure to read the [Breaking Changes section](#breaking-changes) below.
+Pay attention to any new code merged into the dev branch of the official repository.
+If this occurs, you will need to pick-up these changes in your fork using the rebase
+instructions in our [guide to getting started with GitHub](GettingStartedWithGitHub.md).
+
+If you are making a breaking change, please make sure to read the
+[Breaking Changes section](#breaking-changes) below.
 
 ### Write Tests
-All DSC modules in the DscResources should have tests written using [Pester](https://github.com/pester/Pester) included in the Tests folder.
+
+All DSC modules in the DscResources should have tests written using
+[Pester](https://github.com/pester/Pester) included in the Tests folder.
 You are required to provide adequate test coverage for the code you change.
 
 The tests in the following modules provide excellent examples:
-* [NetworkingDsc](https://github.com/PowerShell/NetworkingDsc/tree/dev/Tests)
-* [xDhcpServer](https://github.com/PowerShell/xDhcpServer/tree/master/Tests)
-* [SharePointDsc](https://github.com/PowerShell/SharePointDsc/tree/master/Tests)
 
-We highly encourage you to use our [test templates](https://github.com/PowerShell/DscResources/tree/master/Tests.Template) when creating tests for DSC resources.
-Please refer to our [testing guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) for information on how to use these templates.
+- [NetworkingDsc](https://github.com/PowerShell/NetworkingDsc/tree/dev/Tests)
+- [xDhcpServer](https://github.com/PowerShell/xDhcpServer/tree/master/Tests)
+- [SharePointDsc](https://github.com/PowerShell/SharePointDsc/tree/master/Tests)
+
+We highly encourage you to use our [test templates](https://github.com/PowerShell/DscResources/tree/master/Tests.Template)
+when creating tests for DSC resources.
+Please refer to our [testing guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md)
+for information on how to use these templates.
 Our test templates and guidelines are currently under construction.
 Use them with caution as they may be changed soon.
 
 Tests should currently be structured like so:
 
-* Root folder of module
-    * Tests
-        * Unit
-            * MyResource.Tests.ps1
-        * Integration
-            * MyResource.Integration.Tests.ps1
+- Root folder of module
+  - Tests
+    - Unit
+      - MyResource.Tests.ps1
+    - Integration
+      - MyResource.Integration.Tests.ps1
 
 Not all resources currently have tests.
 This does not mean that you do not have to write tests for your changes.
-If you find that the test file for a resource is missing or one of the folders in the structure outlined above is missing, please create it.
-You don't have to write the full set of tests for the resource if you are creating the file.
+If you find that the test file for a resource is missing or one of the folders
+in the structure outlined above is missing, please create it.
+You don't have to write the full set of tests for the resource if you are
+creating the file.
 You only need to test the changes that you made to the resource.
 
 ### Update the Release Notes
+
 Release notes for each module are included in the README.md file under the root folder.
-Currently unreleased changes are listed under the 'Unreleased' section under the 'Versions' header.
+Currently unreleased changes are listed under the 'Unreleased' section under the
+'Versions' header.
 If this section is missing, please add it.
 
-To update the release notes with your changes, simply add a bullet point (or more) with your changes in the **past** tense under the 'Unreleased' section.
+To update the release notes with your changes, simply add a bullet point (or more)
+with your changes in the **past** tense under the 'Unreleased' section.
 For example:
-```
+
+```plaintext
 ...
 ## Versions
 
@@ -189,9 +258,12 @@ For example:
 ### 1.4.0.0
 ...
 ```
-If a change is related to a specific resource, please add sub-bullets with your changes under a bullet with the resource name.
+
+If a change is related to a specific resource, please add sub-bullets with your
+changes under a bullet with the resource name.
 Like so:
-```
+
+```plaintext
 ...
 ## Versions
 
@@ -207,12 +279,16 @@ Like so:
 ...
 ```
 
-If you are making a breaking change, please make sure to read the [Breaking Changes section](#breaking-changes) below.
+If you are making a breaking change, please make sure to read the
+[Breaking Changes section](#breaking-changes) below.
 
 ### Submit a Pull Request
-A [pull request](https://help.github.com/articles/using-pull-requests/) (PR) allows you to submit the changes you made in your fork to the official repository.
 
-To open a pull request, go to the Pull Requests tab of either your fork or the official repository.
+A [pull request](https://help.github.com/articles/using-pull-requests/) (PR)
+allows you to submit the changes you made in your fork to the official repository.
+
+To open a pull request, go to the Pull Requests tab of either your fork or the
+official repository.
 ![GitHubPullRequestsTabInFork.png](Images/GitHubPullRequestsTabInFork.png)
 
 Click the New Pull Request button on the right:
@@ -220,15 +296,21 @@ Click the New Pull Request button on the right:
 
 The base is the repository and branch the pull request will be merging **into**.
 The target is the repository and branch the pull request will be merging **from**.
-For the DSC Resource Kit, always create a pull request with the base as the **dev** branch of the official repository.
-(Except for *this* repository - DscResources - which does not have a dev branch because it does not get released to the PowerShellGallery. For this repository you may create a pull request to the master branch.)
+For the DSC Resource Kit, always create a pull request with the base as the **dev**
+branch of the official repository.
+(Except for *this* repository - DscResources - which does not have a dev branch
+because it does not get released to the PowerShellGallery. For this repository
+you may create a pull request to the master branch.)
 The target should be your working branch in your fork.
 ![Github-PR-dev.png](Images/Github-PR-dev.png)
 
-Once you select the correct base and target, you can review the file and commits that will be included in the pull request by selecting the tabs below the Create Pull Requests Button:
+Once you select the correct base and target, you can review the file and commits
+that will be included in the pull request by selecting the tabs below the Create
+Pull Requests Button:
 ![GitHubPullRequestFileReview.png](Images/GitHubPullRequestFileReview.png)
 
-If GitHub tells you that your branches cannot automatically be merged, you probably have merge conflicts. These should be fixed before you submit your pull request.
+If GitHub tells you that your branches cannot automatically be merged, you probably
+have merge conflicts. These should be fixed before you submit your pull request.
 ![GitHubPullRequestPreCreateMergeConflict.png](Images/GitHubPullRequestPreCreateMergeConflict.png)
 
 For help fixing merge conflicts see our [guide to getting started with GitHub](GettingStartedWithGitHub.md).
@@ -237,29 +319,43 @@ Once you are ready to submit your pull request, click the Create Pull Request bu
 ![GitHubCreatePullRequestButton.png](Images/GitHubCreatePullRequestButton.png)
 
 #### Pull Request Title
+
 The title of your PR should *describe* the changes it includes in one line.
 Simply putting the issue number that the PR fixes is not acceptable.
-If your PR deals with *one* specific resource, please prefix the title with the resource name followed by a colon.
-If your PR fixes an issue please do still include "(Fixes #issue number)" in the title.
-For example, if a PR fixes issues number 11 and 16 which adds the Ensure parameter to the xSample resource, the title should be something like:
+If your PR deals with *one* specific resource, please prefix the title with the
+resource name followed by a colon.
+If your PR fixes an issue please do still include "(Fixes #issue number)" in the
+title.
+For example, if a PR fixes issues number 11 and 16 which adds the Ensure parameter
+to the xSample resource, the title should be something like:
 "xSample: Added Ensure parameter (Fixes #11, #16)".
 
-If your pull request includes a breaking change, please refer to the [Breaking Changes](#breaking-changes) section below.
+If your pull request includes a breaking change, please refer to the
+[Breaking Changes](#breaking-changes) section below.
 
-If you open a pull request with the wrong title, you can easily edit it by clicking the Edit button to the right of the title in the open pull request.
+If you open a pull request with the wrong title, you can easily edit it by
+clicking the Edit button to the right of the title in the open pull request.
 
 #### Pull Request Description
-The description of your PR should include a detailed report of all the changes you made.
-If your PR fixes an issue please include the number in the description.
-Please tag anyone you would specifically like to see this PR with the @ symbol followed by their GitHub username (e.g. @kwirkykat).
 
-Once you are satisfied with the title, description and file changes included, submit the pull request.
+The description of your PR should include a detailed report of all the changes
+you made.
+If your PR fixes an issue please include the number in the description.
+Please tag anyone you would specifically like to see this PR with the @ symbol
+followed by their GitHub username (e.g. @kwirkykat).
+
+Once you are satisfied with the title, description and file changes included,
+submit the pull request.
 
 #### Contribution License Agreement (CLA)
-If this is your first contribution to the DSC Resource Kit, you may be asked to sign a [Contribution Licensing Agreement](https://cla.microsoft.com/) (CLA) before your changes can be reviewed:
+
+If this is your first contribution to the DSC Resource Kit, you may be asked to
+sign a [Contribution Licensing Agreement](https://cla.microsoft.com/) (CLA) before
+your changes can be reviewed:
 ![GitHubCLARequired.png](Images/GitHubCLARequired.png)
 
-Once you sign the CLA, the Microsoft CLA bot will automatically update the comment in your PR:
+Once you sign the CLA, the Microsoft CLA bot will automatically update the comment
+in your PR:
 ![GitHubCLASigned.png](Images/GitHubCLASigned.png)
 
 The CLA status check should also pass in your PR.
@@ -271,24 +367,35 @@ marks your PR as "CLA not signed yet", or the CLA status check does not pass,
 please sign the CLA again. Sometimes the little bot makes mistakes.
 
 ### Tests in AppVeyor
-The DSC Resource Kit uses [AppVeyor](http://www.appveyor.com/) as a continuous integration (CI) system.
 
-After submitting your pull request, AppVeyor will automatically run a suite of tests on your submitted changes.
-Afterwards, AppVeyor will update the status of the pull request, providing at-a-glance feedback about whether your changes are passing tests or not.
+The DSC Resource Kit uses [AppVeyor](http://www.appveyor.com/) as a continuous
+integration (CI) system.
+
+After submitting your pull request, AppVeyor will automatically run a suite of
+tests on your submitted changes.
+Afterwards, AppVeyor will update the status of the pull request, providing at-a-glance
+feedback about whether your changes are passing tests or not.
 ![AppVeyor-Github](Images/AppVeyor-Github.png)
 
 All the green checkboxes and red crosses are **clickable**.
-They will bring you to the corresponding test page with details on which tests are running and why your tests may be failing.
+They will bring you to the corresponding test page with details on which tests
+are running and why your tests may be failing.
 
-A maintainer **will not** merge your pull request if these tests are failing, even if they have nothing to do with your changes.
-If test failures are occurring that do not relate to the changes you made, you will have to submit another PR with fixes for those failures or wait until someone else does.
+A maintainer **will not** merge your pull request if these tests are failing, even
+if they have nothing to do with your changes.
+If test failures are occurring that do not relate to the changes you made, you will
+have to submit another PR with fixes for those failures or wait until someone else
+does.
 
-Any commit to the working branch that is the target of the pull request will trigger the tests to run again in AppVeyor.
+Any commit to the working branch that is the target of the pull request will trigger
+the tests to run again in AppVeyor.
 If you tag a maintainer, they can also re-run your tests in AppVeyor.
 
-The appveyor.yml file in each module repository describes the build and test sequence provided to AppVeyor.
+The appveyor.yml file in each module repository describes the build and test
+sequence provided to AppVeyor.
 
-An AppVeyor badge indicating the latest build status of the **master** branch is at the top of the README.md file of every DSC Resource repository.
+An AppVeyor badge indicating the latest build status of the **master** branch is
+at the top of the README.md file of every DSC Resource repository.
 ![AppVeyor-Badge-Green.png](Images/AppVeyor-Badge-Green.png)
 
 This badge is also **clickable**.
@@ -296,46 +403,69 @@ It opens the corresponding module's AppVeyor page which shows test logs and resu
 From this page you can easily navigate through the build history of the module.
 
 #### Common Tests
-There is a set of common tests for all DSC Resources located in the [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) repository.
-These tests primarily concentrate on code style, file encoding, correct module schema, and PS Script Analyzer issues.
+
+There is a set of common tests for all DSC Resources located in the
+[DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) repository.
+These tests primarily concentrate on code style, file encoding, correct module
+schema, and PS Script Analyzer issues.
 
 You should run these tests before submitting a pull request.
 
-For some modules, the common DSC Resources tests are automatically downloaded into the root module folder when tests are invoked.
+For some modules, the common DSC Resources tests are automatically downloaded
+into the root module folder when tests are invoked.
 
-If this is not happening for your module, you will need to clone [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) into the root folder of the module that you want to test.
+If this is not happening for your module, you will need to clone
+[DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) into the root
+folder of the module that you want to test.
 Then simply run `Invoke-Pester` from the root folder.
 
 Like this:
-```
+
+```plaintext
 cd C:\MyPath\ResourceModuleFolder
 git clone https://github.com/PowerShell/DscResource.Tests
 Invoke-Pester
 ```
 
 Please avoid adding the **DSCResource.Tests** folder to your changes.
-DSCResource.Tests should be in the .gitignore file so that git will automatically ignore this folder.
+DSCResource.Tests should be in the .gitignore file so that git will automatically
+ignore this folder.
 If DSCResource.Tests is not in the .gitignore file, please add it.
-If there is no .gitignore file for your module, instructions on how to add one are available in our [getting started with GitHub](GettingStartedWithGitHub.md) instructions.
+If there is no .gitignore file for your module, instructions on how to add one are
+available in our [getting started with GitHub](GettingStartedWithGitHub.md) instructions.
 
-The [MetaFixers](https://github.com/PowerShell/DscResource.Tests/blob/master/MetaFixers.psm1) module also in [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) contains a few fix-helper methods such as a function to convert all tab indentations to 4 spaces and a function to fix file encodings.
+The [MetaFixers](https://github.com/PowerShell/DscResource.Tests/blob/master/MetaFixers.psm1)
+module also in [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests)
+contains a few fix-helper methods such as a function to convert all tab indentations
+to 4 spaces and a function to fix file encodings.
 
 ### Fix Merge Conflicts
+
 If you have merge conflicts, please use Git rebasing to fix them instead of Git merging.
-An introduction to Git rebasing is available in the [getting started with GitHub](GettingStartedWithGitHub.md) instructions.
+An introduction to Git rebasing is available in the [getting started with GitHub](GettingStartedWithGitHub.md)
+instructions.
 
 ### Get your Code Reviewed
-Anyone other than you can *review* your code, but only maintainers can *merge* your code.
-If you have a specific contributor/maintainer you want to review your code, be sure to tag them in your pull request.
 
-We don't currently have dedicated maintainers for most modules, so it may take a while for a general maintainer to get around to your pull request.
+Anyone other than you can *review* your code, but only maintainers can *merge*
+your code.
+If you have a specific contributor/maintainer you want to review your code, be
+sure to tag them in your pull request.
+
+We don't currently have dedicated maintainers for most modules, so it may take a
+while for a general maintainer to get around to your pull request.
 Please be patient.
 
 ## Breaking Changes
-Breaking changes should first be proposed by opening an issue on the resource and outlining the needed work.
-This allows the community to discuss the change before the work is done and scopes the breaks to needed areas.
 
-Opening an issue also allows the resource owner or the DSC Resource Kit Owner ([@kwirkykat](https://github.com/kwirkykat)) to tag the issue with the ```breaking change``` label.
+Breaking changes should first be proposed by opening an issue on the resource and
+outlining the needed work.
+This allows the community to discuss the change before the work is done and scopes
+the breaks to needed areas.
+
+Opening an issue also allows the resource owner or the DSC Resource Kit Owner
+([@kwirkykat](https://github.com/kwirkykat)) to tag the issue with the
+```breaking change``` label.
 
 Breaking changes may include:
 
@@ -346,147 +476,217 @@ Breaking changes may include:
 
 Once a PR is ready with the breaking change please include the following:
 
-1. At least one of the bullet points in your addition to the updated release notes starts with 'BREAKING CHANGE:'
-2. The title of the PR that includes your breaking change starts with 'BREAKING CHANGE:'
+1. At least one of the bullet points in your addition to the updated release notes
+  starts with 'BREAKING CHANGE:'
+1. The title of the PR that includes your breaking change starts with 'BREAKING CHANGE:'
 
 ## Submitting a New Resource
-If you would like to add a new DSC resource, please open an issue in the repository you think the new resource should be in.
+
+If you would like to add a new DSC resource, please open an issue in the repository
+you think the new resource should be in.
 This will help to coordinate your work with other contributors.
 
-Once the issue is open, you may begin working on your resource just as if you were fixing the issue you submitted.
+Once the issue is open, you may begin working on your resource just as if you were
+fixing the issue you submitted.
 See the [Fixing an Issue](#fixing-an-issue) section above for further details.
 
-Be sure to include unit and integration tests for your new resource under the Tests folder as well as an example under the examples folder.
-Please also add a full description of your new resource and its parameters to the module's README.
+Be sure to include unit and integration tests for your new resource under the
+Tests folder as well as an example under the examples folder.
+Please also add a full description of your new resource and its parameters to the
+module's README.
 
 ### Resource Naming
 
-All mof-based resource (with Get/Set/Test-TargetResource and a schema.mof file) files should have MSFT_ appended before the resource name (e.g. MSFT_xResource.psm1). This is per a convention that the name (or abbreviated name) of the company that provides the resource be included in the name of mof-based resource files. The friendly name of the resource, defined in the mof file, should not have the MSFT_ prefix.
+All mof-based resource (with Get/Set/Test-TargetResource and a schema.mof file)
+files should have MSFT_ appended before the resource name (e.g. MSFT_xResource.psm1).
+This is per a convention that the name (or abbreviated name) of the company that
+provides the resource be included in the name of mof-based resource files. The friendly
+name of the resource, defined in the mof file, should not have the MSFT_ prefix.
 
-Composite resource (with a configuration and a .psd1 file) files must have the exact same name as the resource or they will not be able to be imported. Hence, composite resource files should not have the MSFT_ prefix (e.g. xResource.psm1).
+Composite resource (with a configuration and a .psd1 file) files must have the exact
+same name as the resource or they will not be able to be imported. Hence, composite
+resource files should not have the MSFT_ prefix (e.g. xResource.psm1).
 
-If you are adding a new resource to an unsupported module (module name starts with 'x'), the resource name must also start with 'x' (e.g. MSFT_xResource.psm1 or xResource.psm1).
-If the module name does not start with 'x', the resource name should not start with 'x' (e.g. MSFT_Resource.psm1 or Resource.psm1).
+If you are adding a new resource to an unsupported module (module name starts with
+'x'), the resource name must also start with 'x' (e.g. MSFT_xResource.psm1 or xResource.psm1).
+If the module name does not start with 'x', the resource name should not start with
+'x' (e.g. MSFT_Resource.psm1 or Resource.psm1).
 
-Any test or example files for the resource should be named to match the files for the same resource. For example, if the main resource file is named 'MSFT_xResource.psm1', then the unit test file should be named 'MSFT_xResource.Tests.ps1'. Consistent naming helps the review process.
+Any test or example files for the resource should be named to match the files for
+the same resource. For example, if the main resource file is named
+'MSFT_xResource.psm1', then the unit test file should be named 'MSFT_xResource.Tests.ps1'.
+Consistent naming helps the review process.
 
 For more details, please see [Naming](Naming.md).
 
 ## Submitting a New Resource Module
-This repository is **not** accepting new modules at this time. We recommend authoring the resource in your own repository and [submitting it to the gallery](https://docs.microsoft.com/en-us/powershell/gallery/psgallery/creating-and-publishing-an-item) under your own name. However, feel free to bring up any modules you have authored during the [DSC Resoucrce Kit Community Call](https://github.com/PowerShell/DscResources/tree/master/CommunityCalls).
+
+This repository is **not** accepting new modules at this time. We recommend authoring
+the resource in your own repository and
+[submitting it to the gallery](https://docs.microsoft.com/en-us/powershell/gallery/psgallery/creating-and-publishing-an-item)
+under your own name. However, feel free to bring up any modules you have authored
+during the [DSC Resoucrce Kit Community Call](https://github.com/PowerShell/DscResources/tree/master/CommunityCalls).
 
 ## Developing a new resource
 
 Make sure to:
 
-* Follow the standard DSC Resource Kit module structure.
+- Follow the standard DSC Resource Kit module structure.
   Here is an example:
-  * Root folder (e.g. SampleResourceModuleDsc)
-    * DscResources
-      * SampleResource
-        * SampleResource.psm1
-        * SampleResource.schema.mof
-    * Tests
-      * Unit
-        * SampleResource.Tests.ps1
-      * Integration
-        * SampleResource.Integration.Tests.ps1
-    * Examples
-      * SampleResource.Example.ps1
-    * Module manifest (e.g. SampleResourceModuleDsc.psd1)
-    * README.md
-    * appveyor.yml
-* Write a set of unit and integration tests for your new resources using Pester.
-* Use the template from the repository [DscResource.Template](https://github.com/PowerShell/DscResource.Template) as a boilerplate for [appveyor.yml](https://github.com/PowerShell/DscResource.Template/blob/master/appveyor.yml) (Continuous Integration configuration file) and [README.md](https://github.com/PowerShell/DscResource.Template/blob/master/README.md).
-* Run the common tests located in [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests) which will be automatically installed into the root folder of your module when your tests are run if your module is accepted in the DSC Resource Kit.
+  - Root folder (e.g. SampleResourceModuleDsc)
+    - DscResources
+      - SampleResource
+        - SampleResource.psm1
+        - SampleResource.schema.mof
+    - Tests
+      - Unit
+        - SampleResource.Tests.ps1
+      - Integration
+        - SampleResource.Integration.Tests.ps1
+    - Examples
+      - SampleResource.Example.ps1
+    - Module manifest (e.g. SampleResourceModuleDsc.psd1)
+    - README.md
+    - appveyor.yml
+- Write a set of unit and integration tests for your new resources using Pester.
+- Use the template from the repository [DscResource.Template](https://github.com/PowerShell/DscResource.Template)
+  as a boilerplate for [appveyor.yml](https://github.com/PowerShell/DscResource.Template/blob/master/appveyor.yml)
+  (Continuous Integration configuration file) and [README.md](https://github.com/PowerShell/DscResource.Template/blob/master/README.md).
+- Run the common tests located in [DSCResource.Tests](https://github.com/PowerShell/DscResource.Tests)
+  which will be automatically installed into the root folder of your module when
+  your tests are run if your module is accepted in the DSC Resource Kit.
 
-All new resources in existing resource modules should should follow the [High Quality resource module guidelines](HighQualityModuleGuidelines.md).
+All new resources in existing resource modules should should follow the
+[High Quality resource module guidelines](HighQualityModuleGuidelines.md).
 
 ## Writing Documentation
-One of the easiest ways to contribute to a PowerShell project is to write and edit documentation.
-All documentation in the DSC Resource Kit uses [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/) (GFM).
+
+One of the easiest ways to contribute to a PowerShell project is to write and
+edit documentation.
+All documentation in the DSC Resource Kit uses [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/)
+(GFM).
 See the [section below](#github-flavored-markdown) for more details.
 
-If you want to contribute new documentation, first check for existing issues to make sure you're not duplicating efforts.
+If you want to contribute new documentation, first check for existing issues to
+make sure you're not duplicating efforts.
 If no one seems to be working on what you have planned:
 
-1. Open a new issue to tell others about the documentation change/addition you'd like to make.
-2. Create a fork of the repository you would like the documentation to be added to.
-3. Edit or add the Markdown file (.md) you would like changed/added.
-  To edit an existing file in the GitHub editor, simply navigate to it in GitHub and click the Edit button.
-4. When you're ready to contribute your documentation, [submit a pull request](#submit-a-pull-request) to the official repository.
+1. Open a new issue to tell others about the documentation change/addition you'd
+  like to make.
+1. Create a fork of the repository you would like the documentation to be added to.
+1. Edit or add the Markdown file (.md) you would like changed/added.
+  To edit an existing file in the GitHub editor, simply navigate to it in GitHub
+  and click the Edit button.
+1. When you're ready to contribute your documentation, [submit a pull request](#submit-a-pull-request)
+  to the official repository.
 
-#### GitHub Flavored Markdown
-If you are looking for a good editor, try the web interface GitHub provides for .md files or [Markdown Pad](http://markdownpad.com/).
+### GitHub Flavored Markdown
+
+If you are looking for a good editor, try the web interface GitHub provides for
+.md files or [Markdown Pad](http://markdownpad.com/).
 A great guide to Github Flavored Markdown is available [here](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
 
 ## Reviewing Pull Requests
-Though only maintainers can *merge* a pull request, anyone from the community can *review* a pull request.
-Maintainers will still take a quick look at code before merging it, but reviews by community members often help pull requests get merged much faster as there are very few maintainers and a lot of pull requests to review.
 
-All pull requests across all modules in the DSC Resource Kit that are open for review can be seen in the Needs Review column on our [dashboard](https://waffle.io/powershell/dscresources/join).
+Though only maintainers can *merge* a pull request, anyone from the community
+can *review* a pull request.
+Maintainers will still take a quick look at code before merging it, but reviews
+by community members often help pull requests get merged much faster as there are
+very few maintainers and a lot of pull requests to review.
+
+All pull requests across all modules in the DSC Resource Kit that are open for
+review can be seen in the Needs Review column on our [dashboard](https://waffle.io/powershell/dscresources/join).
 
 **Pull requests should not be reviewed while tests from AppVeyor are failing.**
-If you are confused why tests in AppVeyor are failing, tag a maintainer or ask the community for help.
+If you are confused why tests in AppVeyor are failing, tag a maintainer or ask
+the community for help.
 
-All modules in the DSC Resource Kit should be linked to [Reviewable](https://reviewable.io), a code review tool.
+All modules in the DSC Resource Kit should be linked to [Reviewable](https://reviewable.io),
+a code review tool.
 Reviewable adds a purple button to the top comment of every pull request.
 ![GitHubReviewableButton](Images/GitHubReviewableButton.png)
 This button is **clickable**.
 It will take you to a code review of all the changes in that pull request.
 
-If the purple Reviewable button does not appear, you can also go [here](https://reviewable.io/reviews) and paste the URL of the pull request you would like to review into this box towards the bottom of the page:
+If the purple Reviewable button does not appear, you can also go [here](https://reviewable.io/reviews)
+and paste the URL of the pull request you would like to review into this box
+towards the bottom of the page:
 ![ReviewablePullRequestPasteBox](Images/ReviewablePullRequestPasteBox.png)
 
-If a pull request contains a lot of changed files, Reviewable may collapse them and show you only one file at a time. If this happens, you can navigate to other files in the pull request by clicking the purple reviewable icon at the top of the page:
+If a pull request contains a lot of changed files, Reviewable may collapse them
+and show you only one file at a time. If this happens, you can navigate to other
+files in the pull request by clicking the purple reviewable icon at the top of
+the page:
 ![ReviewableFilePicker](Images/ReviewableFilePicker.png)
 
 ### Making Review Comments
-You can make a comment in Reviewable either in the top discussion section (for general/overall comments) or you can click on a line of code to make a comment at that line.
-Each comment you make will be saved as a draft so that you can continue making comments until you are ready to publish all of them at once. Publishing is discussed in the [Publish Review Changes](#publish-review-changes) section below.
-If you want to delete a comment draft at a line of code, click the tiny trash icon at the bottom of the comment.
+
+You can make a comment in Reviewable either in the top discussion section (for
+general/overall comments) or you can click on a line of code to make a comment
+at that line.
+Each comment you make will be saved as a draft so that you can continue making
+comments until you are ready to publish all of them at once. Publishing is
+discussed in the [Publish Review Changes](#publish-review-changes) section below.
+If you want to delete a comment draft at a line of code, click the tiny trash
+icon at the bottom of the comment.
 
 Some things to pay attention to while reviewing:
 
-* Does the code logic make sense?
-* Does the code structure make sense?
-* Does this make the resource better?
-* Is the code easy to read?
-* Do all variables, parameters, and functions have **descriptive** names? (e.g. no $params, $args, $i, $a, etc.)
-* Does every function have a help comment?
-* Does the code follow the DSC Resource Kit [Style Guidelines](StyleGuidelines.md) and [Best Practices](BestPractices.md)?
-* Has the author included test coverage for their changes?
-* Has the author updated the Unreleased section of the README with their changes?
+- Does the code logic make sense?
+- Does the code structure make sense?
+- Does this make the resource better?
+- Is the code easy to read?
+- Do all variables, parameters, and functions have **descriptive** names? (e.g.
+  no $params, $args, $i, $a, etc.)
+- Does every function have a help comment?
+- Does the code follow the DSC Resource Kit [Style Guidelines](StyleGuidelines.md)
+  and [Best Practices](BestPractices.md)?
+- Has the author included test coverage for their changes?
+- Has the author updated the Unreleased section of the README with their changes?
 
 ### Resolving Review Discussions
-When the author replies or makes the changes you requested and you are **satisfied** with the changes/reply, you will need to resolve the discussion. You can do this in one of two ways:
+
+When the author replies or makes the changes you requested and you are **satisfied**
+with the changes/reply, you will need to resolve the discussion. You can do this
+in one of two ways:
 
 1. Click the Acknowledge button on the comment
 ![ReviewableAcknowledgeButton](Images/ReviewableAcknowledgeButton.png)
-2. Click the small circle in the bottom right of the comment and select 'Satisfied'.
+1. Click the small circle in the bottom right of the comment and select 'Satisfied'.
 ![ReviewableDiscussionStatusCircle](Images/ReviewableDiscussionStatusCircle.png)
 ![ReviewableDiscussionSatisfied](Images/ReviewableDiscussionSatisfied.png)
 
 ### Marking Files as Reviewed
-To mark an entire file as reviewed, click the little eye button next to the file name at the top of the file so that it turns green.
+
+To mark an entire file as reviewed, click the little eye button next to the file
+name at the top of the file so that it turns green.
 ![ReviewableFileReviewButtonRed](Images/ReviewableFileReviewButtonRed.png)
 ![ReviewableFileReviewButtonGreen](Images/ReviewableFileReviewButtonGreen.png)
 
 ### Approving a Pull Request
-Please mark all files and discussions as resolved before you approve the entire pull request.
 
-To approve the pull request, you can click the LGTM (looks good to me) button in the main discussion at the top of the code review in Reviewable:
+Please mark all files and discussions as resolved before you approve the entire
+pull request.
+
+To approve the pull request, you can click the LGTM (looks good to me) button in
+the main discussion at the top of the code review in Reviewable:
 ![ReviewableLGTMButton](Images/ReviewableLGTMButton.png)
-Or you can simply comment on the pull request on GitHub "Looks good to me" or a thumbs up.
+Or you can simply comment on the pull request on GitHub "Looks good to me" or a
+thumbs up.
 
 ### Publishing Review Changes
-To push your comments and files marked as reviewed to the pull request on GitHub, you will need to publish your changes.
+
+To push your comments and files marked as reviewed to the pull request on GitHub,
+you will need to publish your changes.
 This can be done two different ways:
 
 1. (RECOMMENDED) Click the large green Publish button at the top of the page:
   ![ReviewablePublishButton](Images/ReviewablePublishButton.png)
-  This will publish all your changes at once and submit them as one comment to the pull request on GitHub.
-2. (NOT RECOMMENDED) Click the small publish button on a comment.
+  This will publish all your changes at once and submit them as one comment to
+  the pull request on GitHub.
+1. (NOT RECOMMENDED) Click the small publish button on a comment.
   This will publish only that one comment as its own separate comment on Github.
-  Please do not publish this way as it will often send a separate email for each comment to whoever is watching the pull request on GitHub.
-  This method also will **not** publish the files you have marked as reviewed with the little eye button.
+  Please do not publish this way as it will often send a separate email for each
+  comment to whoever is watching the pull request on GitHub.
+  This method also will **not** publish the files you have marked as reviewed with
+  the little eye button.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Here's the general process of fixing an issue in the DSC Resource Kit:
 
 Issues that are currently up-for-grabs are tagged with the ```help wanted``` label.
 You can see all the issues tagged with ```help wanted``` across all the modules
-in the DSC Resource Kit in the Help Wanted column on our [dashboard](https://waffle.io/powershell/dscresources/join).
+in the DSC Resource Kit in the Help Wanted column on our [dashboard](https://github.com/orgs/PowerShell/projects/1).
 
 If you find an issue that you want to work on, but it does not have the
 ```help wanted``` label, make sure to read through the issue and ask if you can
@@ -595,7 +595,7 @@ by community members often help pull requests get merged much faster as there ar
 very few maintainers and a lot of pull requests to review.
 
 All pull requests across all modules in the DSC Resource Kit that are open for
-review can be seen in the Needs Review column on our [dashboard](https://waffle.io/powershell/dscresources/join).
+review can be seen in the Needs Review column on our [dashboard](https://github.com/orgs/PowerShell/projects/1).
 
 **Pull requests should not be reviewed while tests from AppVeyor are failing.**
 If you are confused why tests in AppVeyor are failing, tag a maintainer or ask

--- a/CommunityAgenda.md
+++ b/CommunityAgenda.md
@@ -8,10 +8,13 @@
 
 - 08/07/19
 
-All changes for the release should be merged into the `dev` branch before the release date. 
-Resource modules that are not passing their tests in the release pull request from the `dev` branch to the `master` branch cannot be released.  
-Resource modules with open issues labeled `blocking release` cannot be released.  
-Individual resource module hotfixes for urgent issues may be released before the official release date on a case-by-case basis.  
+All changes for the release should be merged into the `dev` branch before the
+release date.
+Resource modules that are not passing their tests in the release pull request
+from the `dev` branch to the `master` branch cannot be released.
+Resource modules with open issues labeled `blocking release` cannot be released.
+Individual resource module hotfixes for urgent issues may be released before the
+official release date on a case-by-case basis.
 
 ### Latest Release
 
@@ -72,7 +75,8 @@ Individual resource module hotfixes for urgent issues may be released before the
 - [05/08/19 12PM-1PM PST](https://github.com/PowerShell/DscResources/blob/master/CommunityCalls/2019-05-08)
 - [03/27/19 12PM-1PM PST](https://github.com/PowerShell/DscResources/blob/master/CommunityCalls/2019-03-27)
 - [02/13/19 12PM-1PM PST](https://github.com/PowerShell/DscResources/blob/master/CommunityCalls/2019-02-13)
-- [01/09/19 12PM-1PM PST](https://github.com/PowerShell/DscResources/blob/master/CommunityCalls/2019-01-09) - [watch here](https://youtu.be/hH2XkR-YZNQ)
+- [01/09/19 12PM-1PM PST](https://github.com/PowerShell/DscResources/blob/master/CommunityCalls/2019-01-09)
+  -- [watch here](https://youtu.be/hH2XkR-YZNQ)
 - 11/28/18 12-1PM PST - cancelled due to technical issues
 - [10/10/18 12-1PM PST](https://github.com/PowerShell/DscResources/blob/master/CommunityCalls/2018-10-10)
 - [08/29/18 12-1PM PST](https://github.com/PowerShell/DscResources/blob/master/CommunityCalls/2018-08-29)

--- a/GettingStartedWithGitHub.md
+++ b/GettingStartedWithGitHub.md
@@ -137,10 +137,10 @@ to send changes there.
 
 ```plaintext
 > git remote -v
-my	https://github.com/vors/xActiveDirectory (fetch)
-my	https://github.com/vors/xActiveDirectory (push)
-origin	https://github.com/PowerShell/xActiveDirectory (fetch)
-origin	https://github.com/PowerShell/xActiveDirectory (push)
+my      https://github.com/vors/xActiveDirectory (fetch)
+my      https://github.com/vors/xActiveDirectory (push)
+origin  https://github.com/PowerShell/xActiveDirectory (fetch)
+origin  https://github.com/PowerShell/xActiveDirectory (push)
 ```
 
 Now you have two remote references:
@@ -497,4 +497,5 @@ In a PowerShell prompt, you need to do the following.
    git push my changes-from-PR#<number> --force  # Change to the PR number, i.e. git push my changes-from-PR#34 --force
    ```
 
-1. Now, go to you forked repository on GitHub and create the pull request the normal way.
+1. Now, go to you forked repository on GitHub and create the pull request the
+  normal way.

--- a/Maintainers.md
+++ b/Maintainers.md
@@ -1,12 +1,14 @@
 # DSC Resource Kit Maintainers
 
-Maintainers are trusted contributors with knowledge in a resource module domain who have [write access](https://help.github.com/articles/permission-levels-for-an-organization-repository/) to one or more DSC Resource Kit repositories.
+Maintainers are trusted contributors with knowledge in a resource module domain
+who have [write access](https://help.github.com/articles/permission-levels-for-an-organization-repository/)
+to one or more DSC Resource Kit repositories.
 
 Maintainers have the power to:
 
 1. `push`.
-2. Merge pull requests.
-3. Assign labels, milestones and people to [issues](https://guides.github.com/features/issues/).
+1. Merge pull requests.
+1. Assign labels, milestones and people to [issues](https://guides.github.com/features/issues/).
 
 ## Table of Contents
 
@@ -112,23 +114,33 @@ and Mariah Breakey ([@mbreakey3](https://github.com/mbreakey3)).
 If you are maintainer, please follow these rules:
 
 1. **DO** take care of pull requests in a timely manner.
-1. **DO** ensure that each contributor has signed a valid Contributor License Agreement (CLA).
-1. **DO** reply to new issues and pull requests (after you finish reviewing and everything looks good to you, leave a comment like "Looks good to me" or "LGTM" so we know that someone has looked at it and approved it).
+1. **DO** ensure that each contributor has signed a valid Contributor License
+  Agreement (CLA).
+1. **DO** reply to new issues and pull requests (after you finish reviewing and
+  everything looks good to you, leave a comment like "Looks good to me" or "LGTM"
+  so we know that someone has looked at it and approved it).
 1. **DO** make sure contributors are following the [contributor guidelines](https://github.com/PowerShell/DscResources/blob/master/CONTRIBUTING.md).
 1. **DO** ask people to resend a pull request, if it targets [the wrong branch](CONTRIBUTING.md#lifecycle-of-a-pull-request).
 1. **DO** require people to write Pester tests for all new/changed functionality.
-1. **DO** wait for the [CI system](CONTRIBUTING.md#appveyor) build to pass for pull requests.
-1. **DO** encourage contributors to refer to issues in PR title/description (e.g. `Fixes #11`, or `Closes #11`). Edit title if necessary.
-1. **DO** encourage contributors to create meaningful titles for all PRs. Edit title if necessary.
+1. **DO** wait for the [CI system](CONTRIBUTING.md#appveyor) build to pass for
+  pull requests.
+1. **DO** encourage contributors to refer to issues in PR title/description
+  (e.g. `Fixes #11`, or `Closes #11`). Edit title if necessary.
+1. **DO** encourage contributors to create meaningful titles for all PRs. Edit
+  title if necessary.
 1. **DO** verify that all contributors are following the [style guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md).
-1. **DO** verify compliance with any third party code license terms (e.g., requiring attribution, etc.) if the contribution contains third party code.
+1. **DO** verify compliance with any third party code license terms (e.g.,
+  requiring attribution, etc.) if the contribution contains third party code.
 
-1. **DON'T** merge pull requests where the CLA status check (`license/cla`) is pending or the CLA status check is missing (updated by Microsoft CLA bot).
+1. **DON'T** merge pull requests where the CLA status check (`license/cla`) is
+  pending or the CLA status check is missing (updated by Microsoft CLA bot).
 1. **DON'T** merge pull requests to **master** branch.
 1. **DON'T** merge pull requests with a failed CI build.
-1. **DON'T** merge pull requests that do not [include all meaningful changes](CONTRIBUTING.md#lifecycle-of-a-pull-request) under the **Unreleased** section in the repository's `README.md` or `CHANGELOG.md`.
+1. **DON'T** merge pull requests that do not [include all meaningful changes](CONTRIBUTING.md#lifecycle-of-a-pull-request)
+  under the **Unreleased** section in the repository's `README.md` or `CHANGELOG.md`.
 1. **DON'T** merge your own pull requests before they are reviewed by someone else.
-    - If there is **no one** else to review your pull request, please wait **24** hours to merge it in case anyone comes along and has a comment.
+    - If there is **no one** else to review your pull request, please wait **24**
+      hours to merge it in case anyone comes along and has a comment.
 
 ## Repeating Tasks
 
@@ -175,30 +187,51 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 
 #### License File contents
 
-The LICENSE file should appear as shown in [LICENSE](https://github.com/PowerShell/DscResources/blob/master/LICENSE), indentation included.
+The LICENSE file should appear as shown in [LICENSE](https://github.com/PowerShell/DscResources/blob/master/LICENSE),
+indentation included.
 
 ## Issue Workflow
 
 1. Someone creates an issue.
-1. A maintainer assigns one of the following labels: ```bug```, ```enhancement```, ```discussion```, ```question```
-  1. In some cases, other special labels may be used (e.g. ```module proposal``` for issues requesting new DSC resource modules in the DscResources repository)
-  1. If the issue is a duplicate of another issue, the maintainer adds the ```duplicate``` label, references the issue this one is a duplicate of, and closes the issue.
-  1. If the issue is external to your module, the maintainer adds the ```external``` label, comments with an explanation of why the issue will not be fixed, and closes the issue.
-  1. If for some other reason an issue should not be fixed, the maintainer adds the ```not fixed``` label, comments with an explanation of why the issue will not be fixed, and closes the issue.
-1. A maintainer assigns the ```help wanted``` label to let contributors know this issue needs someone else to look at it
-1. Once a contributor volunteers to work on the issue, the maintainer removes the ```help wanted``` label, adds the ```in progress``` label, and assigns the issue to the volunteer.
-1. Once issue is fixed, the maintainer removes the ```in progress``` label and closes the issue.
+1. A maintainer assigns one of the following labels: ```bug```, ```enhancement```,
+  ```discussion```, ```question```
+   1. In some cases, other special labels may be used (e.g. ```module proposal```
+     for issues requesting new DSC resource modules in the DscResources repository)
+   1. If the issue is a duplicate of another issue, the maintainer adds the ```duplicate```
+     label, references the issue this one is a duplicate of, and closes the issue.
+   1. If the issue is external to your module, the maintainer adds the ```external```
+     label, comments with an explanation of why the issue will not be fixed, and
+     closes the issue.
+   1. If for some other reason an issue should not be fixed, the maintainer adds
+     the ```not fixed``` label, comments with an explanation of why the issue will
+     not be fixed, and closes the issue.
+1. A maintainer assigns the ```help wanted``` label to let contributors know this
+  issue needs someone else to look at it
+1. Once a contributor volunteers to work on the issue, the maintainer removes the
+  ```help wanted``` label, adds the ```in progress``` label, and assigns the issue
+  to the volunteer.
+1. Once issue is fixed, the maintainer removes the ```in progress``` label and
+  closes the issue.
 
 ## Pull Request Workflow
 
 1. A contributor opens a pull request.
-2. The contributor ensures that their pull request passes the [CI system](CONTRIBUTING.md#appveyor) build.
-  - If the build fails, a maintainer adds the `waiting for code fix` label to the pull request. The contributor can then continue to update the pull request until the build passes.
-2. Once the build passes, the maintainer either reviews the pull request immediately or adds the ```needs review``` label.
-3. A maintainer or trusted contributor reviews the pull request code.
-  - If the contributor does not meet the reviewer's standards, the reviewer makes comments. A maintainer then removes the the ```needs review``` label and adds the ```waiting for code fix``` label. The contributor must address the comments and repeat from step 2.
-  - If the contributor meets the reviewer's standards, the reviewer comments that they are satisfied. A maintainer then removes the the ```needs review``` label.
-3. Once the code review is completed, a maintainer merges the pull request.
+1. The contributor ensures that their pull request passes the [CI system](CONTRIBUTING.md#appveyor)
+  build.
+   - If the build fails, a maintainer adds the `waiting for code fix` label to the
+     pull request. The contributor can then continue to update the pull request
+     until the build passes.
+1. Once the build passes, the maintainer either reviews the pull request immediately
+  or adds the ```needs review``` label.
+1. A maintainer or trusted contributor reviews the pull request code.
+   - If the contributor does not meet the reviewer's standards, the reviewer makes
+     comments. A maintainer then removes the the ```needs review``` label and adds
+     the ```waiting for code fix``` label. The contributor must address the comments
+     and repeat from step 2.
+   - If the contributor meets the reviewer's standards, the reviewer comments
+   that they are satisfied. A maintainer then removes the the ```needs review```
+   label.
+1. Once the code review is completed, a maintainer merges the pull request.
 
 ### Pull Requests waiting for CLA pass
 
@@ -210,31 +243,49 @@ author should be closed.
 
 ### Abandoned Pull Requests
 
-A pull request with the label `waiting for code fix` or `waiting for author response` for **more than 2 weeks** without word from the author is considered abandoned.
+A pull request with the label `waiting for code fix` or `waiting for author response`
+for **more than 2 weeks** without word from the author is considered abandoned.
 
 In these cases:
 
 1. Ping the author of PR to remind him of pending changes.
-   - If the contributor responds, it's no longer an abandoned pull request, proceed as normal.
+   - If the contributor responds, it's no longer an abandoned pull request, proceed
+   as normal.
 1. If the contributor does not respond **within a week**:
-   - If the reviewer's comments are very minor, merge the change, fix the code immediately, and create a new PR with the fixes addressing the minor comments.
-   - If the changes required to merge the pull request are significant but needed, create a new branch with the changes and open an issue to merge the code into the dev branch. Mention the original pull request ID in the description of the new issue and close the abandoned pull request.
-   - If the changes in an abandoned pull request are no longer needed (e.g. due to refactoring of the codebase or a design change), simply close the pull request.
+   - If the reviewer's comments are very minor, merge the change, fix the code
+     immediately, and create a new PR with the fixes addressing the minor comments.
+   - If the changes required to merge the pull request are significant but needed,
+     create a new branch with the changes and open an issue to merge the code into
+     the dev branch. Mention the original pull request ID in the description of
+     the new issue and close the abandoned pull request.
+   - If the changes in an abandoned pull request are no longer needed (e.g. due
+     to refactoring of the codebase or a design change), simply close the pull request.
 
 ## Breaking Changes
+
 Breaking changes may be accepted if they make a resource better.
 Breaking changes usually include:
+
 - Adding a new mandatory parameter
 - Changing an existing parameter
 - Removing an existing parameter
 - Fundamentally changing an existing functionality of a resource
 
 If you need to accept a breaking change in your module please please ensure:
-1. Any issues or PRs associated with the breaking change include the ```breaking change``` label.
-2. At least one of the bullet points in the updated release notes starts with 'BREAKING CHANGE:'.
-3. The title of the PR that includes the breaking change starts with 'BREAKING CHANGE:'.
+
+1. Any issues or PRs associated with the breaking change include the
+  ```breaking change``` label.
+1. At least one of the bullet points in the updated release notes starts with
+  'BREAKING CHANGE:'.
+1. The title of the PR that includes the breaking change starts with 'BREAKING CHANGE:'.
 
 Upon release, the version of a module with a breaking change will be updated as such:
-* Modules that still have the x... naming are incremented by a full version number if there is a breaking change (2.2.0.0 --> 3.0.0.0). All of these modules are still considered to be in the 'preview' or 'experimental' phase.
-* Modules that have the ...Dsc naming but are still in the 'preview' phase (prior to 1.0.0.0) are incremented only by a sub-version regardless of breaking changes until they are ready to come out of preview (0.3.0.0 --> 0.4.0.0).
-* Modules that have the ...Dsc naming and are out of the 'preview' phase (1.0.0.0 and after) are incremented by a full version number (2.2.0.0 --> 3.0.0.0).
+
+- Modules that still have the x... naming are incremented by a full version number
+  if there is a breaking change (2.2.0.0 --> 3.0.0.0). All of these modules are
+  still considered to be in the 'preview' or 'experimental' phase.
+- Modules that have the ...Dsc naming but are still in the 'preview' phase (prior
+  to 1.0.0.0) are incremented only by a sub-version regardless of breaking changes
+  until they are ready to come out of preview (0.3.0.0 --> 0.4.0.0).
+- Modules that have the ...Dsc naming and are out of the 'preview' phase (1.0.0.0
+  and after) are incremented by a full version number (2.2.0.0 --> 3.0.0.0).

--- a/Naming.md
+++ b/Naming.md
@@ -79,10 +79,11 @@ When DSC was originally introduced,
 it was communicated that new modules should be prefixed with an "x"
 to help identify that the work might not be suitable for use in a production environment.
 
-The community has now matured and guidelines exist to hold project maintainers accountable
-through the use of CI process where tests are required and the results are publicly available.
-Anyone that would like to evaluate the quality of a module can view the project documentation,
-code, tests, and test results, to understand if the work is suitable for their environment.
+The community has now matured and guidelines exist to hold project maintainers
+accountable through the use of CI process where tests are required and the results
+are publicly available. Anyone that would like to evaluate the quality of a module
+can view the project documentation, code, tests, and test results, to understand
+if the work is suitable for their environment.
 
 The "x" prefix is no longer required.
 Resources that include the prefix are free to deprecate the convention going forward.

--- a/NewResourceModuleSubmissions.md
+++ b/NewResourceModuleSubmissions.md
@@ -15,8 +15,8 @@ Prior to listing in DSC Resource repository under [DscResources](https://github.
 ## First step
 
 When you think your resource module is ready for listing in DSC Resource Kit,
-then the first step is to create a new issue using the *New resource module submission* issue
-template. It should include all the information needed to make a successful
+then the first step is to create a new issue using the *New resource module submission*
+issue template. It should include all the information needed to make a successful
 resource module submission (including the above information).
 
 >***Note:** You can look at the template to get the information without submitting

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DSC Resources
 
 [![Join the chat on PowerShell Slack #DSC](https://img.shields.io/badge/Slack-PowerShell-blue.svg)](https://j.mp/psslack)
+[![Join the chat on PowerShell Slack #DSC Discord](https://img.shields.io/badge/Discord-PowerShell-blue.svg)](https://j.mp/psdiscord)
 
 This is the central repository for the DSC Resource Kit, a collection of DSC
 resources maintained and released by Microsoft.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the central repository for the DSC Resource Kit, a collection of DSC
 resources maintained and released by Microsoft.
 
 A dashboard of all open issues and pull requests across DSC Resource Kit is
-available on the [DSC Resource Kit Waffle board](http://waffle.io/powershell/dscresources).
+available on the [DSC Resource Kit GitHub Project board](https://github.com/orgs/PowerShell/projects/1).
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DSC Resources
 
-[![Join the chat at https://gitter.im/PowerShell/DscResources](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/PowerShell/DscResources?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat on PowerShell Slack #DSC](https://img.shields.io/badge/Slack-PowerShell-blue.svg)](https://j.mp/psslack)
 
 This is the central repository for the DSC Resource Kit, a collection of DSC
 resources maintained and released by Microsoft.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 [![Join the chat at https://gitter.im/PowerShell/DscResources](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/PowerShell/DscResources?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-This is the central repository for the DSC Resource Kit, a collection of DSC resources maintained and released by Microsoft.
+This is the central repository for the DSC Resource Kit, a collection of DSC
+resources maintained and released by Microsoft.
 
-A dashboard of all open issues and pull requests across DSC Resource Kit is available on the [DSC Resource Kit Waffle board](http://waffle.io/powershell/dscresources).
+A dashboard of all open issues and pull requests across DSC Resource Kit is
+available on the [DSC Resource Kit Waffle board](http://waffle.io/powershell/dscresources).
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
+questions or comments.
 
 ## Support
 
@@ -15,8 +19,10 @@ Please review the DSC Resource Kit support guidelines [here](https://github.com/
 
 ## New to PowerShell DSC
 
-Desired State Configuration (DSC) is a declarative management platform in PowerShell to configure, deploy, and manage systems.
-If you are new to DSC, configurations, or resources, you can learn more about them [here](https://docs.microsoft.com/en-us/powershell/dsc/overview).
+Desired State Configuration (DSC) is a declarative management platform in PowerShell
+to configure, deploy, and manage systems.
+If you are new to DSC, configurations, or resources, you can learn more about
+them [here](https://docs.microsoft.com/en-us/powershell/dsc/overview).
 
 ## Resource Module Source Code
 
@@ -30,18 +36,22 @@ For example, for the CertificateDsc module, go to:
 
 `https://github.com/PowerShell/CertificateDsc`
 
-All DSC resource modules are also listed as submodules of this repository (DscResources) in the [xDscResources folder](https://github.com/PowerShell/DscResources/tree/master/xDscResources) or [DscResources folder](https://github.com/PowerShell/DscResources/tree/master/DscResources).
+All DSC resource modules are also listed as submodules of this repository (DscResources)
+in the [xDscResources folder](https://github.com/PowerShell/DscResources/tree/master/xDscResources)
+or [DscResources folder](https://github.com/PowerShell/DscResources/tree/master/DscResources).
 Read about the differences in naming under the
 [High Quality Resource Module](https://github.com/PowerShell/DscResources/blob/master/Naming.md#high-quality-resource-module)
 section.
 
-To download the released source code for **all** DSC resource modules, clone this repository with this git command:
+To download the released source code for **all** DSC resource modules, clone this
+repository with this git command:
 
 ```shell
 git clone https://github.com/PowerShell/DscResources.git --recursive
 ```
 
-Alternatively, to download just the documentation provided in this repository, clone this repository with this git command:
+Alternatively, to download just the documentation provided in this repository, clone
+this repository with this git command:
 
 ```shell
 git clone https://github.com/PowerShell/DscResources.git
@@ -49,9 +59,12 @@ git clone https://github.com/PowerShell/DscResources.git
 
 ## Released DSC Resource Modules
 
-To see a list of **all** released DSC Resource Kit modules, go to the [PowerShell Gallery](http://www.powershellgallery.com/) and display [all modules tagged as DSCResourceKit](http://www.powershellgallery.com/packages?q=Tags%3A%22DSCResourceKit%22).
+To see a list of **all** released DSC Resource Kit modules, go to the
+[PowerShell Gallery](http://www.powershellgallery.com/) and display
+[all modules tagged as DSCResourceKit](http://www.powershellgallery.com/packages?q=Tags%3A%22DSCResourceKit%22).
 
-To find a **specific** module, enter the module's name in the search box in the upper right corner of the PowerShell Gallery or go directly to its URL:
+To find a **specific** module, enter the module's name in the search box in the
+upper right corner of the PowerShell Gallery or go directly to its URL:
 http://www.powershellgallery.com/packages/< module name >
 For example:
 http://www.powershellgallery.com/packages/xWebAdministration
@@ -68,13 +81,15 @@ For example:
 Install-Module -Name xWebAdministration
 ```
 
-To update all previously installed modules at once, open an elevated PowerShell prompt and use this command:
+To update all previously installed modules at once, open an elevated PowerShell
+prompt and use this command:
 
 ```powershell
 Update-Module
 ```
 
-After installing modules, you can discover all DSC resources available to your local system with this command:
+After installing modules, you can discover all DSC resources available to your
+local system with this command:
 
 ```powershell
 Get-DscResource
@@ -82,15 +97,24 @@ Get-DscResource
 
 ## Contributing to the Resource Modules
 
-You are more than welcome to contribute to the development of the DSC Resource Kit. There are several different ways you can help. You can create new DSC resources or modules, add test automation, improve documentation, fix existing issues, or open new ones.
-See our [contributing guide](https://github.com/PowerShell/DscResources/blob/master/CONTRIBUTING.md) for more info on how to become a DSC Resource Kit contributor.
+You are more than welcome to contribute to the development of the DSC Resource Kit.
+There are several different ways you can help. You can create new DSC resources or
+modules, add test automation, improve documentation, fix existing issues, or open
+new ones.
+See our [contributing guide](https://github.com/PowerShell/DscResources/blob/master/CONTRIBUTING.md)
+for more info on how to become a DSC Resource Kit contributor.
 
 ## Resource Module Maintainers
 
-To see a list of the maintainers for each resource modules as well as the instructions for maintaining a module, see our [guidelines for DSC resource maintainers](Maintainers.md).
+To see a list of the maintainers for each resource modules as well as the instructions
+for maintaining a module, see our [guidelines for DSC resource maintainers](Maintainers.md).
 
-## Questions, Comments, Concerns?
+## Questions, Comments, Concerns
 
-If you're looking into using PowerShell DSC, have questions or issues with a current resource, or would like a new resource, let us know on Twitter ([@PowerShell_Team](https://twitter.com/PowerShell_Team)) or by creating an issue on [GitHub](https://github.com/powershell/dscresources/issues).
+If you're looking into using PowerShell DSC, have questions or issues with a current
+resource, or would like a new resource, let us know on Twitter ([@PowerShell_Team](https://twitter.com/PowerShell_Team))
+or by creating an issue on [GitHub](https://github.com/powershell/dscresources/issues).
 
-The PowerShell team also hosts DSC Resource Kit community calls to give updates, collect feedback, and answer questions. Find the date of the next call in our [community agenda](CommunityAgenda.md).
+The PowerShell team also hosts DSC Resource Kit community calls to give updates,
+collect feedback, and answer questions. Find the date of the next call in our
+[community agenda](CommunityAgenda.md).

--- a/Release.md
+++ b/Release.md
@@ -1,24 +1,66 @@
 # DSC Resource Kit Release Process
 
 1. (Script) Get all pull requests merged since the last release tag date
-2. (Manual) Look at the pull requests and determine whether the module should be released or not. Modules that only have updates in documentation, tests, or examples may not be released to PowerShell Gallery unless it is specially requested.
-3. (Manual) Determine the new version of the updated module. Modules with breaking changes have their major version updated. Modules without breaking changes have only their minor version updated.
-4. (Manual) Make sure that release notes are present in the `README.md` or `CHANGELOG.md` file of the resource. The script will print an error and will not update the module for release if release notes are not present in either of these two files.
-5. (Manual) Make sure there are no issues open on the module repository that are labeled as `blocking release`.
-6. (Script) Run the DSC resource module release script. This script will perform the following actions:
+1. (Manual) Look at the pull requests and determine whether the module should
+  be released or not. Modules that only have updates in documentation, tests,
+  or examples may not be released to PowerShell Gallery unless it is specially
+  requested.
+1. (Manual) Determine the new version of the updated module. Modules with breaking
+  changes have their major version updated. Modules without breaking changes have
+  only their minor version updated.
+1. (Manual) Make sure that release notes are present in the `README.md` or `CHANGELOG.md`
+  file of the resource. The script will print an error and will not update the module
+  for release if release notes are not present in either of these two files.
+1. (Manual) Make sure there are no issues open on the module repository that are
+  labeled as `blocking release`.
+1. (Script) Run the DSC resource module release script. This script will perform
+  the following actions:
     1. Clone the dev branch of the module from GitHub
-    2. Replace the version in the module manifest with the new version (provided as a parameter to the script). To find the module manifest, the script will search for any file named `ModuleName.psd1` in the repository. If more than one file is found it will try to pick the one in the root directory of the module.
-    3. In the file containing the release notes, add a new markdown header with the title as the new version of the module underneath the header with the title 'Unreleased'. To find the file that contains the release notes, the script will look for `README.md` at the root of the repository. If that file does not exist then it will look for `CHANGELOG.md` at the root of the repository. If no release notes are found, the script will error and the update of the module will be stopped.
-    4. Get the release notes from the file containing the release notes. To find the file that contains the release notes, the script will first attempt to find any file in the module named `README.md`. If more than one file is found it will try to pick the one in the root directory of the module. Then it will attempt to find the header with the title `Release Notes` in that file. If there is no file named `README.md` or the file does not contain the `Release Notes` header, then the script will look for any file in the repository named `CHANGELOG.md`. If more than one file is found it will try to pick the one in the root directory of the module. Then it will attempt to find the header with the title `Release Notes` in that file. If no release notes are found, the script will error and the update of the module will be stopped.
-    5. Retrieve the release notes by getting the text between the new version header and the next markdown version header.
-    6. Replace all single quote characters in the release notes with double quotes (this prevents the manifest from getting messed up).
-    7. Remove all pound characters from the release notes (the manifest views these as comment characters).
-    8. Add the release notes with the edited characters to the module manifest by finding the `ReleaseNotes` property and replacing all text between two single quotes after that property. To find the module manifest, the script will search for any file named `ModuleName.psd1` in the repository. If more than one file is found it will try to pick the one in the root directory of the module.
-    9. Commit and push these changes to the dev branch on GitHub
-    10. Create the release pull request from the dev branch to the master branch.
-7. (Manual) Verify that all release pull requests were correctly opened.
-8. (Manual) Verify that the module version and release notes were correctly changed in the module manifest, and these changes are part of the release pull request.
-9. (Manual) Wait for the tests to pass on the release pull request. If they do not pass, evaluate if the test fix is a quick fix or a problem in the testing system. If it looks like the test will require a code change, open an issue on the test failure with the label `blocking release` alert the repository maintainer if the repository has one.
-10. (Manual) Merge the release pull request.
-11. (Script) Create a release tag at the latest commit in master and push it to the repository.
-12. (Script) Publish the module from the master branch to the PowerShell Gallery.
+    1. Replace the version in the module manifest with the new version (provided
+      as a parameter to the script). To find the module manifest, the script will
+      search for any file named `ModuleName.psd1` in the repository. If more than
+      one file is found it will try to pick the one in the root directory of the
+      module.
+    1. In the file containing the release notes, add a new markdown header with the
+      title as the new version of the module underneath the header with the title
+      'Unreleased'. To find the file that contains the release notes, the script
+      will look for `README.md` at the root of the repository. If that file does
+      not exist then it will look for `CHANGELOG.md` at the root of the repository.
+      If no release notes are found, the script will error and the update of the
+      module will be stopped.
+    1. Get the release notes from the file containing the release notes. To find
+      the file that contains the release notes, the script will first attempt to
+      find any file in the module named `README.md`. If more than one file is found
+      it will try to pick the one in the root directory of the module. Then it will
+      attempt to find the header with the title `Release Notes` in that file. If
+      there is no file named `README.md` or the file does not contain the
+      `Release Notes` header, then the script will look for any file in the repository
+      named `CHANGELOG.md`. If more than one file is found it will try to pick the
+      one in the root directory of the module. Then it will attempt to find the
+      header with the title `Release Notes` in that file. If no release notes are
+      found, the script will error and the update of the module will be stopped.
+    1. Retrieve the release notes by getting the text between the new version
+      header and the next markdown version header.
+    1. Replace all single quote characters in the release notes with double quotes
+      (this prevents the manifest from getting messed up).
+    1. Remove all pound characters from the release notes (the manifest views
+      these as comment characters).
+    1. Add the release notes with the edited characters to the module manifest by
+      finding the `ReleaseNotes` property and replacing all text between two single
+      quotes after that property. To find the module manifest, the script will search
+      for any file named `ModuleName.psd1` in the repository. If more than one file
+      is found it will try to pick the one in the root directory of the module.
+    1. Commit and push these changes to the dev branch on GitHub
+    1. Create the release pull request from the dev branch to the master branch.
+1. (Manual) Verify that all release pull requests were correctly opened.
+1. (Manual) Verify that the module version and release notes were correctly changed
+  in the module manifest, and these changes are part of the release pull request.
+1. (Manual) Wait for the tests to pass on the release pull request. If they do not
+  pass, evaluate if the test fix is a quick fix or a problem in the testing system.
+  If it looks like the test will require a code change, open an issue on the test
+  failure with the label `blocking release` alert the repository maintainer if the
+  repository has one.
+1. (Manual) Merge the release pull request.
+1. (Script) Create a release tag at the latest commit in master and push it to
+  the repository.
+1. (Script) Publish the module from the master branch to the PowerShell Gallery.

--- a/StyleGuidelines.md
+++ b/StyleGuidelines.md
@@ -1,8 +1,12 @@
 # DSC Resource Style Guidelines & Best Practices
 
-In order to provide clean and consistent code, please follow the [style guidelines](#style-guidelines) listed below when contributing to any [DSC Resource Kit repositories](https://github.com/PowerShell/DscResources/tree/master/xDscResources).
+In order to provide clean and consistent code, please follow the
+[style guidelines](#style-guidelines) listed below when contributing to any
+[DSC Resource Kit repositories](https://github.com/PowerShell/DscResources/tree/master/xDscResources).
 
-It is recommended to also follow the guidance from the [best practices](#best-practices) section, although this is not required unless the module aims to meet the [High Quality Resource Module](HighQualityModuleGuidelines.md) standards.
+It is recommended to also follow the guidance from the [best practices](#best-practices)
+section, although this is not required unless the module aims to meet the
+[High Quality Resource Module](HighQualityModuleGuidelines.md) standards.
 
 ## Table of Contents
 
@@ -105,14 +109,17 @@ It is recommended to also follow the guidance from the [best practices](#best-pr
 ### Markdown Files
 
 If a paragraph includes more than one sentence, end each sentence with a newline.
-GitHub will still render the sentences as a single paragraph, but the readability of `git diff` will be greatly improved.
+GitHub will still render the sentences as a single paragraph, but the readability
+of `git diff` will be greatly improved.
 
 ### General
 
 #### Correct File Encoding
 
-Make sure all files are encoded using UTF-8 (not UTF-8 with BOM), except mof files which should be encoded using ASCII.
-You can use ```ConvertTo-UTF8``` and ```ConvertTo-ASCII``` to convert a file to UTF-8 or ASCII.
+Make sure all files are encoded using UTF-8 (not UTF-8 with BOM), except mof files
+which should be encoded using ASCII.
+You can use ```ConvertTo-UTF8``` and ```ConvertTo-ASCII``` to convert a file to
+UTF-8 or ASCII.
 
 #### Descriptive Names
 
@@ -551,15 +558,18 @@ $string = "String that evaluate variable '{0}'" -f $SomeObject.SomeProperty
 There should not be any commented-out code in checked-in files.
 The first letter of the comment should be capitalized.
 
-Single line comments should be on their own line and start with a single pound-sign followed by a single space.
-The comment should be indented the same amount as the following line of code.
+Single line comments should be on their own line and start with a single pound-sign
+followed by a single space. The comment should be indented the same amount as the
+following line of code.
 
-Comments that are more than one line should use the ```<# #>``` format rather than the single pound-sign.
-The opening and closing brackets should be on their own lines.
-The comment inside the brackets should be indented once more than the brackets.
-The brackets should be indented the same amount as the following line of code.
+Comments that are more than one line should use the ```<# #>``` format rather
+than the single pound-sign. The opening and closing brackets should be on their
+own lines. The comment inside the brackets should be indented once more than the
+brackets. The brackets should be indented the same amount as the following line
+of code.
 
-Formatting help-comments for functions has a few more specific rules that can be found [here](#all-functions-must-have-comment-based-help).
+Formatting help-comments for functions has a few more specific rules that can be
+found [here](#all-functions-must-have-comment-based-help).
 
 **Bad:**
 
@@ -720,11 +730,13 @@ All files must end with a newline, see [StackOverflow.](http://stackoverflow.com
 #### Newline Character Encoding
 
 Save [newlines](http://en.wikipedia.org/wiki/Newline) using CR+LF instead of CR.
-For interoperability reasons, we recommend that you follow [these instructions](GettingStartedWithGitHub.md#setup-git) when installing Git on Windows so that newlines saved to GitHub are simply CRs.
+For interoperability reasons, we recommend that you follow [these instructions](GettingStartedWithGitHub.md#setup-git)
+when installing Git on Windows so that newlines saved to GitHub are simply CRs.
 
 #### No More Than Two Consecutive Newlines
 
-Code should not contain more than two consecutive newlines unless they are contained in a here-string.
+Code should not contain more than two consecutive newlines unless they are contained
+in a here-string.
 
 **Bad:**
 
@@ -799,7 +811,8 @@ if ($booleanValue)
 }
 ```
 
-When assigning to a variable, opening curly braces should be on the same line as the assignment operator.
+When assigning to a variable, opening curly braces should be on the same line as
+the assignment operator.
 
 **Bad:**
 
@@ -875,8 +888,11 @@ function Get-MyValue
 
 #### Two Newlines After Closing Brace
 
-Each closing curly brace **ending** a function, conditional block, loop, etc. should be followed by exactly two newlines unless it is directly followed by another closing brace.
-If the closing brace is followed by another closing brace or continues a conditional or switch block, there should be only one newline after the closing brace.
+Each closing curly brace **ending** a function, conditional block, loop, etc.
+should be followed by exactly two newlines unless it is directly followed by another
+closing brace. If the closing brace is followed by another closing brace or continues
+a conditional or switch block, there should be only one newline after the closing
+brace.
 
 **Bad:**
 
@@ -930,7 +946,8 @@ Get-MyValue
 
 #### One Space Between Type and Variable Name
 
-If you must declare a variable type, type declarations should be separated from the variable name by a single space.
+If you must declare a variable type, type declarations should be separated from
+the variable name by a single space.
 
 **Bad:**
 
@@ -1016,7 +1033,8 @@ function Get-TargetResource
 
 #### One Space Between Keyword and Parenthesis
 
-If a keyword is followed by a parenthesis, there should be single space between the keyword and the parenthesis.
+If a keyword is followed by a parenthesis, there should be single space between
+the keyword and the parenthesis.
 
 **Bad:**
 
@@ -1128,8 +1146,9 @@ function ConvertTo-NormalizedString
 
 #### Functions Have Comment-Based Help
 
-All functions should have comment-based help with the correct syntax directly above the function.
-Comment-help should include at least the SYNOPSIS section and a PARAMETER section for each parameter.
+All functions should have comment-based help with the correct syntax directly
+above the function. Comment-help should include at least the SYNOPSIS section and
+a PARAMETER section for each parameter.
 
 **Bad:**
 
@@ -1190,8 +1209,9 @@ function New-Event
 #### Parameter Block at Top of Function
 
 There must be a parameter block declared for every function.
-The parameter block must be at the top of the function and not declared next to the function name.
-Functions with no parameters should still display an empty parameter block.
+The parameter block must be at the top of the function and not declared next to
+the function name. Functions with no parameters should still display an empty
+parameter block.
 
 **Bad:**
 
@@ -1243,12 +1263,17 @@ function Write-Nothing
 
 #### Correct Format for Parameter Block
 
-- An empty parameter block should be displayed on its own line like this: `param ()`.
-- A non-empty parameter block should have the opening and closing parentheses on their own line.
+- An empty parameter block should be displayed on its own line like this:
+  `param ()`.
+- A non-empty parameter block should have the opening and closing parentheses on
+  their own line.
 - All text inside the parameter block should be indented once.
-- Every parameter should include the `[Parameter()]` attribute, regardless of whether the attribute requires decoration or not.
-- A parameter that is mandatory should contain this decoration: `[Parameter(Mandatory = $true)]`.
-- A parameter that is not mandatory should _not_ contain a `Mandatory` decoration in the `[Parameter()]`.
+- Every parameter should include the `[Parameter()]` attribute, regardless of
+  whether the attribute requires decoration or not.
+- A parameter that is mandatory should contain this decoration:
+  `[Parameter(Mandatory = $true)]`.
+- A parameter that is not mandatory should _not_ contain a `Mandatory` decoration
+  in the `[Parameter()]`.
 
 **Bad:**
 
@@ -1459,7 +1484,8 @@ function New-Event
 #### Parameter Type on Line Above
 
 The parameter type must be on its own line above the parameter name.
-If an attribute needs to follow the type, it should also have its own line between the parameter type and the parameter name.
+If an attribute needs to follow the type, it should also have its own line between
+the parameter type and the parameter name.
 
 **Bad:**
 
@@ -1528,7 +1554,8 @@ function New-Event
 #### Parameter Attributes on Separate Lines
 
 Parameter attributes should each have their own line.
-All attributes should go above the parameter type, except those that *must* be between the type and the name.
+All attributes should go above the parameter type, except those that *must* be
+between the type and the name.
 
 **Bad:**
 
@@ -1604,9 +1631,10 @@ function Write-Log
 
 #### Script, Environment and Global Variable Names Include Scope
 
-Script, environment, and global variables must always include their scope in the variable name unless the 'using' scope is needed.
-The script and global scope specifications should be all in lowercase.
-Script and global variable names following the scope should use camelCase.
+Script, environment, and global variables must always include their scope in the
+variable name unless the 'using' scope is needed. The script and global scope
+specifications should be all in lowercase. Script and global variable names following
+the scope should use camelCase.
 
 **Bad:**
 
@@ -1639,8 +1667,8 @@ function New-File
 Although adoping the _best practices_ is optional, doing so will help improve the
 quality of the DSC resource module.
 
-Note: Modules that aim to meet the [High Quality Resource Module](HighQualityModuleGuidelines.md) standards
-must also implement the _best practices_ whereever possible.
+Note: Modules that aim to meet the [High Quality Resource Module](HighQualityModuleGuidelines.md)
+standards must also implement the _best practices_ whereever possible.
 
 ### General Best Practices
 
@@ -1648,7 +1676,8 @@ must also implement the _best practices_ whereever possible.
 
 Using hardcoded computer names exposes sensitive information on your machine.
 Use a parameter or environment variable instead if a computer name is necessary.
-This comes from [this](https://github.com/PowerShell/PSScriptAnalyzer/blob/development/RuleDocumentation/AvoidUsingComputerNameHardcoded.md) PS Script Analyzer rule.
+This comes from [this](https://github.com/PowerShell/PSScriptAnalyzer/blob/development/RuleDocumentation/AvoidUsingComputerNameHardcoded.md)
+PS Script Analyzer rule.
 
 **Bad:**
 
@@ -1666,7 +1695,8 @@ Invoke-Command -Port 0 -ComputerName $env:computerName
 
 Empty catch blocks are not necessary.
 Most errors should be thrown or at least acted upon in some way.
-If you really don't want an error to be thrown or logged at all, use the ErrorAction parameter with the SilentlyContinue value instead.
+If you really don't want an error to be thrown or logged at all, use the ErrorAction
+parameter with the SilentlyContinue value instead.
 
 **Bad:**
 
@@ -1686,10 +1716,14 @@ Get-Command -Name Invoke-NotACommand -ErrorAction SilentlyContinue
 
 #### Ensure Null is on Left Side of Comparisons
 
-When comparing a value to ```$null```, ```$null``` should be on the left side of the comparison.
+When comparing a value to ```$null```, ```$null``` should be on the left side of
+the comparison.
 This is due to an issue in PowerShell.
-If ```$null``` is on the right side of the comparison and the value you are comparing it against happens to be a collection, PowerShell will return true if the collection *contains* ```$null``` rather than if the entire collection actually *is* ```$null```.
-Even if you are sure your variable will never be a collection, for consistency, please ensure that ```$null``` is on the left side of all comparisons.
+If ```$null``` is on the right side of the comparison and the value you are comparing
+it against happens to be a collection, PowerShell will return true if the collection
+*contains* ```$null``` rather than if the entire collection actually *is* ```$null```.
+Even if you are sure your variable will never be a collection, for consistency,
+please ensure that ```$null``` is on the left side of all comparisons.
 
 **Bad:**
 
@@ -1712,12 +1746,15 @@ if ($null -eq $myArray)
 #### Avoid Global Variables
 
 Avoid using global variables whenever possible.
-These variables can be edited by any other script that ran before your script or is running at the same time as your script.
-Use them only with extreme caution, and try to use parameters or script/local variables instead.
+These variables can be edited by any other script that ran before your script or
+is running at the same time as your script.
+Use them only with extreme caution, and try to use parameters or script/local
+variables instead.
 
 This rule has a few exceptions:
 
-- The use of ```$global:DSCMachineStatus``` is still recommended to restart a machine from a DSC resource.
+- The use of ```$global:DSCMachineStatus``` is still recommended to restart a
+  machine from a DSC resource.
 
 **Bad:**
 
@@ -1777,9 +1814,10 @@ function Get-Settings
 
 #### Use Variables Rather Than Extensive Piping
 
-This is a script not a console. Code should be easy to follow.
-There should be no more than 1 pipe in a line.
-This rule is specific to the DSC Resource Kit - other PowerShell best practices may say differently, but this is our preferred format for readability.
+This is a script not a console. Code should be easy to follow. There should be no
+more than 1 pipe in a line. This rule is specific to the DSC Resource Kit - other
+PowerShell best practices may say differently, but this is our preferred format
+for readability.
 
 **Bad:**
 
@@ -1802,8 +1840,8 @@ foreach ($validPropertyObject in $validPropertyObjects)
 
 #### Avoid Unnecessary Type Declarations
 
-If it is clear what type a variable is then it is not necessary to explicitly declare its type.
-Extra type declarations can clutter the code.
+If it is clear what type a variable is then it is not necessary to explicitly
+declare its type. Extra type declarations can clutter the code.
 
 **Bad:**
 
@@ -1845,7 +1883,9 @@ ls -File $root -Recurse | ? { @('.gitignore', '.mof') -contains $_.Extension }
 **Good:**
 
 ```Powershell
-Get-ChildItem -File $root -Recurse | Where-Object { @('.gitignore', '.mof') -contains $_.Extension }
+Get-ChildItem -File $root -Recurse | Where-Object -FilterScript {
+    @('.gitignore', '.mof') -contains $_.Extension
+}
 ```
 
 ### Avoid Invoke-Expression
@@ -1915,9 +1955,10 @@ Write-Verbose -Message 'Setting the variable to a value.'
 
 #### Avoid ConvertTo-SecureString with AsPlainText
 
-SecureStrings should be encrypted.
-When using ConvertTo-SecureString with the AsPlainText parameter specified the SecureString text is not encrypted and thus not secure
-This is allowed in tests/examples when needed, but never in the actual resources.
+SecureStrings should be encrypted. When using ConvertTo-SecureString with the
+`AsPlainText` parameter specified the SecureString text is not encrypted and thus
+not secure. This is allowed in tests/examples when needed, but never in the actual
+resources.
 
 **Bad:**
 
@@ -1947,7 +1988,8 @@ Set-Background -Color $backgroundColor
 
 #### Avoid Default Values for Mandatory Parameters
 
-Default values for mandatory parameters will always be overwritten, thus they are never used and can cause confusion.
+Default values for mandatory parameters will always be overwritten, thus they are
+never used and can cause confusion.
 
 **Bad:**
 
@@ -1985,7 +2027,8 @@ function Get-Something
 
 Switch parameters have 2 values - there or not there.
 The default value is automatically $false so it doesn't need to be declared.
-If you are tempted to set the default value to $true - don't - refactor your code instead.
+If you are tempted to set the default value to $true - don't - refactor your code
+instead.
 
 **Bad:**
 
@@ -2061,12 +2104,15 @@ function Get-Something
 
 #### Avoid Redefining Reserved Parameters
 
-[Reserved Parameters](https://msdn.microsoft.com/en-us/library/dd901844(v=vs.85).aspx ) such as Verbose, Debug, etc. are already added to the function at runtime so don't redefine them.
-Add the CmdletBinding attribute to include the reserved parameters in your function.
+[Reserved Parameters](https://msdn.microsoft.com/en-us/library/dd901844(v=vs.85).aspx)
+such as Verbose, Debug, etc. are already added to the function at runtime so don't
+redefine them. Add the CmdletBinding attribute to include the reserved parameters
+in your function.
 
 #### Use the CmdletBinding Attribute on Every Function
 
-The CmdletBinding attribute adds the reserved parameters to your function which is always preferable.
+The CmdletBinding attribute adds the reserved parameters to your function which is
+always preferable.
 
 **Bad:**
 
@@ -2097,7 +2143,9 @@ function Get-Property
 
 #### Define the OutputType Attribute for All Functions With Output
 
-The OutputType attribute should be declared if the function has output so that the correct error messages get displayed if the function ever produces an incorrect output type.
+The OutputType attribute should be declared if the function has output so that
+the correct error messages get displayed if the function ever produces an incorrect
+output type.
 
 **Bad:**
 
@@ -2202,13 +2250,18 @@ function Get-MyBoolean
 
 #### Get-TargetResource should not contain unused non-mandatory parameters
 
-The inclusion of a non-mandatory parameter that is never used could signal that there is a design flaw in the implementation of the `Get-TargetResource` function.
-The non-mandatory parameters that are used to call `Get-TargetResource` should help to retrieve the actual values of the properties for the resource.
-For example, if there is a parameter `Ensure` that is non-mandatory, that parameter describes the state the resource should have, but it might not be used to retrieve
+The inclusion of a non-mandatory parameter that is never used could signal that
+there is a design flaw in the implementation of the `Get-TargetResource` function.
+The non-mandatory parameters that are used to call `Get-TargetResource` should help
+to retrieve the actual values of the properties for the resource.
+For example, if there is a parameter `Ensure` that is non-mandatory, that parameter
+describes the state the resource should have, but it might not be used to retrieve
 the actual values.
-Another example would be if a parameter `FilePathName` is set to be non-mandatory, but `FilePathName` is actually a property that `Get-TargetResource` should return
+Another example would be if a parameter `FilePathName` is set to be non-mandatory,
+but `FilePathName` is actually a property that `Get-TargetResource` should return
 the actual value of.
-In that case it does not make sense to assign a value to `FilePathName` when calling `Get-TargetResource` because that value will never be used.
+In that case it does not make sense to assign a value to `FilePathName` when
+calling `Get-TargetResource` because that value will never be used.
 
 **Bad:**
 
@@ -2301,19 +2354,26 @@ function Get-TargetResource
 
 #### Any unused parameters that must be included in a function definition should include 'Not used in \<function_name\>' in the help comment for that parameter in the comment-based help
 
-The inclusion of a mandatory parameter in the 'Get-TargetResource' function that is never used could signal that there is a design flaw in the implementation
-of the function.
-The mandatory parameters that are used to call 'Get-TargetResource' should help to retrieve the actual values of the properties for the resource.
-For example, if there is a parameter 'Ensure' that is mandatory, that parameter will not be used to retrieve the actual values.
-Another example would be if a parameter 'FilePathName' is set to be mandatory, but 'FilePathName' is actually a property that 'Get-TargetResource' should
-return the actual value of. In that case it does not make sense to assign a value to 'FilePathName' when calling 'Get-TargetResource' because that value will
-never be used.
+The inclusion of a mandatory parameter in the 'Get-TargetResource' function that
+is never used could signal that there is a design flaw in the implementation of
+the function. The mandatory parameters that are used to call 'Get-TargetResource'
+should help to retrieve the actual values of the properties for the resource.
+For example, if there is a parameter 'Ensure' that is mandatory, that parameter
+will not be used to retrieve the actual values. Another example would be if a
+parameter 'FilePathName' is set to be mandatory, but 'FilePathName' is actually
+a property that 'Get-TargetResource' should return the actual value of. In that
+case it does not make sense to assign a value to 'FilePathName' when calling
+'Get-TargetResource' because that value will never be used.
 
-The inclusion of a mandatory or a non-mandatory parameter in the Test-TargetResource function that is not used is more common since it is required that both
-the 'Set-TargetResource' and the 'Test-TargetResource' have the same parameters. Thus, there will be times when not all of the parameters in the 'Test-TargetResource'
+The inclusion of a mandatory or a non-mandatory parameter in the Test-TargetResource
+function that is not used is more common since it is required that both the
+'Set-TargetResource' and the 'Test-TargetResource' have the same parameters. Thus,
+there will be times when not all of the parameters in the 'Test-TargetResource'
 function will be used in the function.
 
-If there is a need design-wise to include a mandatory parameter that will not be used, then the comment-based help for that parameter should contain the description 'Not used in <function_name>'.
+If there is a need design-wise to include a mandatory parameter that will not be
+used, then the comment-based help for that parameter should contain the description
+'Not used in <function_name>'.
 
 **Bad:**
 
@@ -2709,7 +2769,8 @@ catch
 
 #### Capitalized Pester Assertions
 
-Pester assertions should all start with capital letters. This makes code easier to read.
+Pester assertions should all start with capital letters. This makes code easier
+to read.
 
 **Bad:**
 
@@ -2762,8 +2823,8 @@ It 'Should return something' {
 #### Context Block Messages Start with When
 
 Pester test **outer** `Context` block messages should always start with the word
-'When'. This is to ensure the test results read more naturally as well as helping to
-indentify context messages that aren't defining context.
+'When'. This is to ensure the test results read more naturally as well as helping
+to indentify context messages that aren't defining context.
 
 **Bad:**
 

--- a/Supportability.md
+++ b/Supportability.md
@@ -4,49 +4,44 @@ This document discusses the approach to support for DSC configurations and resou
 published by the community.
 
 This is a community guidance document and not intended to be a legal/support document.
-For information on support programs available from Microsoft Corporation,
-see [the following website](https://support.microsoft.com/en-us/allproducts)
-and the category specific to the product or service where you use PowerShell.
-Support beyond what is described in this page
-might be available with those additional services.
+For information on support programs available from Microsoft Corporation, see
+[the following website](https://support.microsoft.com/en-us/allproducts) and the
+category specific to the product or service where you use PowerShell. Support
+beyond what is described in this page might be available with those additional services.
 
 ## Are DSC resources supported by Microsoft
 
-Microsoft supports PowerShell and the PowerShell Desired State Configuration
-engine, Local Configuration Manager (LCM).
+Microsoft supports PowerShell and the PowerShell Desired State Configuration engine,
+Local Configuration Manager (LCM).
 
 ## What should I expect if I call Microsoft for support on a DSC Resource
 
-When a new support case is opened and the focus is on DSC,
-the person assisting the customer will attempt to resolve the issue
-and if needed will include engineering support such as the PowerShell team.
+When a new support case is opened and the focus is on DSC, the person assisting
+the customer will attempt to resolve the issue and if needed will include engineering
+support such as the PowerShell team.
 
-The PowerShell team would determine if there is an issue with PowerShell or with LCM.
-If help is needed beyond those areas the case might lead to guiding the customer
-to open a new issue in that community project (GitHub repo),
-a recommendation to engage a 3rd party company/organization that published the DSC Resource,
-or escalation with other teams at Microsoft.
-With community supported artifacts,
+The PowerShell team would determine if there is an issue with PowerShell or with
+LCM. If help is needed beyond those areas the case might lead to guiding the customer
+to open a new issue in that community project (GitHub repo), a recommendation to
+engage a 3rd party company/organization that published the DSC Resource, or
+escalation with other teams at Microsoft. With community supported artifacts,
 the case would be closed once a new issue has been submitted to the project.
 
 ## Who provides support for the technologies managed by DSC
 
 The maintainers for DSC resources should clearly identify in the project README
-if additional support is available.
-An example would be if a Microsoft product or service engineering team
-has agreed to extend their support to include DSC resources,
+if additional support is available. An example would be if a Microsoft product or
+service engineering team has agreed to extend their support to include DSC resources,
 or if a 3rd party software company/organization provides support for DSC resources.
 
-A template for documenting this will be available for community maintainers.
-If support is not documented for a project,
-then it defaults to unsupported.
+A template for documenting this will be available for community maintainers. If
+support is not documented for a project, then it defaults to unsupported.
 
 ## How does this apply to the naming of a resources
 
-The naming of DSC resources includes an identifier of quality
-as explained in the [Naming](Naming.md) informational page,
-that is governed by the community of active DSC Resource contributors.
+The naming of DSC resources includes an identifier of quality as explained in the
+[Naming](Naming.md) informational page, that is governed by the community of active
+DSC Resource contributors.
 
 The expression of quality for a DSC Resource is a distinct metric from supportability.
-The concepts of DSC Resource naming and support
-should be considered unrelated.
+The concepts of DSC Resource naming and support should be considered unrelated.

--- a/TestsGuidelines.md
+++ b/TestsGuidelines.md
@@ -10,41 +10,66 @@
        |---Integration
 ```
 
-- The Tests\Unit folder must contain a Test Script for each DSC Resource in the DSC Module with the filename `MSFT_<ResourceName>.tests.ps1`.
-- The Tests\Integration folder should, whenever possible, contain a Test Script for each DSC Resource in the DSC Module with the filename `MSFT_<ResourceName>.integration.tests.ps1`.
-- Each Test Script should contain [Pester](https://github.com/pester/Pester) based tests.
-- Integration tests should be created when possible, but for some DSC resources this may not be possible. For example, when integration tests would cause the testing computer configuration to be damaged.
-- Unit and Integration tests should be created using the Template files that are located in the [DscResource.Template](https://github.com/PowerShell/DscResource.Template/tree/master/Tests) repository.
-- The Unit and Integration test templates require that `Git.exe` be installed and can be found in the `%PATH%` on the testing computer.
-- The Unit and Integration test templates will automatically download or update the [DSCResource.Tests repository](https://github.com/PowerShell/DscResource.Tests) using Git.exe to the DSC Module folder.
-- Ensure that the .gitignore file for the resource module contains **DSCResource.Tests** so that this folder is not accidentally included in a commit to your resource repository.
-- Ensure that when creating or updating unit/integration tests from the Test.Templates the Version number of the test template file used remains in the test file.
+- The Tests\Unit folder must contain a Test Script for each DSC Resource in the
+  DSC Module with the filename `MSFT_<ResourceName>.tests.ps1`.
+- The Tests\Integration folder should, whenever possible, contain a Test Script
+  for each DSC Resource in the DSC Module with the filename `MSFT_<ResourceName>.integration.tests.ps1`.
+- Each Test Script should contain [Pester](https://github.com/pester/Pester) based
+  tests.
+- Integration tests should be created when possible, but for some DSC resources
+  this may not be possible. For example, when integration tests would cause the
+  testing computer configuration to be damaged.
+- Unit and Integration tests should be created using the Template files that are
+  located in the [DscResource.Template](https://github.com/PowerShell/DscResource.Template/tree/master/Tests)
+  repository.
+- The Unit and Integration test templates require that `Git.exe` be installed and
+  can be found in the `%PATH%` on the testing computer.
+- The Unit and Integration test templates will automatically download or update
+  the [DSCResource.Tests repository](https://github.com/PowerShell/DscResource.Tests)
+  using Git.exe to the DSC Module folder.
+- Ensure that the .gitignore file for the resource module contains **DSCResource.Tests**
+  so that this folder is not accidentally included in a commit to your resource
+  repository.
+- Ensure that when creating or updating unit/integration tests from the Test.Templates
+  the Version number of the test template file used remains in the test file.
 
 ## Creating DSC Resource Unit Test Instructions
 
-1. Copy the [`unit_test_template.ps1`](https://github.com/PowerShell/DscResource.Template/blob/master/Tests/Unit/unit_test_template.ps1) to the `\Tests\Unit\` folder and rename to `MSFT_<ResourceName>.tests.ps1`
+1. Copy the [`unit_test_template.ps1`](https://github.com/PowerShell/DscResource.Template/blob/master/Tests/Unit/unit_test_template.ps1)
+  to the `\Tests\Unit\` folder and rename to `MSFT_<ResourceName>.tests.ps1`
 1. Open `MSFT_<ResourceName>.tests.ps1` and customize TODO sections.
-   - **Note: The existing Describe blocks do not have to be used. The blocks included are a common test pattern, but may be completely replaced with a more suitable pattern.**
+   - **Note: The existing Describe blocks do not have to be used. The blocks
+     included are a common test pattern, but may be completely replaced with a
+     more suitable pattern.**
 
-**Important: Please ensure that the test files created retain the version number of the template used to create them.**
+**Important: Please ensure that the test files created retain the version number
+of the template used to create them.**
 
 ## Creating DSC Resource Integration Test Instructions
 
-1. Copy the [`integration_test_template.ps1`](https://github.com/PowerShell/DscResource.Template/blob/master/Tests/Unit/unit_test_template.ps1) to `\Tests\Integration\` folder and rename `MSFT_<ResourceName>.Integration.tests.ps1`
+1. Copy the [`integration_test_template.ps1`](https://github.com/PowerShell/DscResource.Template/blob/master/Tests/Unit/unit_test_template.ps1)
+  to `\Tests\Integration\` folder and rename `MSFT_<ResourceName>.Integration.tests.ps1`
 1. Open `MSFT_<ResourceName>.Integration.tests.ps1` and customize TODO sections.
-1. Copy the [`integration_test_template.config.ps1`](https://github.com/PowerShell/DscResource.Template/blob/master/Tests/Unit/integration_test_template.config.ps1) to `\Tests\Integration\` folder and rename `MSFT_<ResourceName>.config.ps1`
+1. Copy the [`integration_test_template.config.ps1`](https://github.com/PowerShell/DscResource.Template/blob/master/Tests/Unit/integration_test_template.config.ps1)
+  to `\Tests\Integration\` folder and rename `MSFT_<ResourceName>.config.ps1`
 1. Open `MSFT_<ResourceName>.config.ps1` and customize TODO sections.
 
-**Important: Please ensure that the test files created retain the version number of the template used to create them.**
+**Important: Please ensure that the test files created retain the version number
+of the template used to create them.**
 
 ## Updating DSC Resource Tests
 
-It is possible that the Unit and Integration test templates may change in future, either to support new functionality or fix an issue.
-When a change is made to a template, it will be documented in the [change log of the TEMPLATE_README.md in the repository DscResource.Template](https://github.com/PowerShell/DscResource.Template/blob/master/TEMPLATE_README.md#change-log).
-The version number in any current tests can be compared with the Change List to determine what has changed since the tests were updated.
-If any unit or integration tests based on these templates require any enhancements or fixes then they will need to be updated manually.
+It is possible that the Unit and Integration test templates may change in future,
+either to support new functionality or fix an issue. When a change is made to a
+template, it will be documented in the
+[change log of the TEMPLATE_README.md in the repository DscResource.Template](https://github.com/PowerShell/DscResource.Template/blob/master/TEMPLATE_README.md#change-log).
+The version number in any current tests can be compared with the Change List to
+determine what has changed since the tests were updated. If any unit or integration
+tests based on these templates require any enhancements or fixes then they will
+need to be updated manually.
 
-**Important: Please ensure that when updating a test with the new Test Template content that the Template version number is also updated to match the new template.**
+**Important: Please ensure that when updating a test with the new Test Template
+content that the Template version number is also updated to match the new template.**
 
 ## Running Tests Locally
 
@@ -54,12 +79,16 @@ However, it is recommended that all tests be run locally before being committed.
 Requirements for running all tests locally:
 
 1. Git is installed and the `Git.exe` can be found in the `%PATH%` variable.
-1. The latest [Pester Module](https://github.com/pester/Pester) is installed, either manually or via PowerShellGet.
-1. An internet connection is available so that the DSCResource.Tests repository can be downloaded or updated using Git.
+1. The latest [Pester Module](https://github.com/pester/Pester) is installed,
+  either manually or via PowerShellGet.
+1. An internet connection is available so that the DSCResource.Tests repository
+  can be downloaded or updated using Git.
 
 ## Unit Testing Private Functions
 
-If a resource contains private (non-exported) functions that need to be tested, then to allow these functions to be tested by Pester, they must be contained in an `InModuleScope` Pester block:
+If a resource contains private (non-exported) functions that need to be tested,
+then to allow these functions to be tested by Pester, they must be contained
+in an `InModuleScope` Pester block:
 
 ```powershell
 InModuleScope $Global:DSCResourceName {
@@ -69,37 +98,46 @@ InModuleScope $Global:DSCResourceName {
 }
 ```
 
-_Note: The core DSC Resource functions `Get-TargetResource`, `Set-TargetResource` and `Test-TargetResource` must always be public functions, so do not need to be contained in an `InModuleScope` block._
+_Note: The core DSC Resource functions `Get-TargetResource`, `Set-TargetResource`
+and `Test-TargetResource` must always be public functions, so do not need to be
+contained in an `InModuleScope` block._
 
 ## Using Variables Declared by the Module in Tests
 
-It is common for modules to declare variables that are needed inside the module, but may also be required for unit testing.
-One common example of this is the `LocalizedData` variable that contains localized messages used by the resource.
-Variables declared at the module scope (private variables) can not be accessed by unit tests that are not inside an `InModuleScope` Pester block.
+It is common for modules to declare variables that are needed inside the module,
+but may also be required for unit testing. One common example of this is the
+`LocalizedData` variable that contains localized messages used by the resource.
+Variables declared at the module scope (private variables) can not be accessed by
+unit tests that are not inside an `InModuleScope` Pester block.
 
 > **Note:** See [Localization](#localization) section for more information of using
 > localized messages in tests.
 
 There are two solutions to this:
 
-1. Use the `InModuleScope` to copy the private variable into a variable scoped to the Unit test:
+1. Use the `InModuleScope` to copy the private variable into a variable scoped
+  to the Unit test:
 
-```powershell
-$LocalizedData = InModuleScope $Global:DSCResourceName {
-    $LocalizedData
-}
-```
+   ```powershell
+   $LocalizedData = InModuleScope $Global:DSCResourceName {
+       $LocalizedData
+   }
+   ```
 
-2. Add any variables that are required to be accessed outside the module by unit tests to the `Export-ModuleMember` cmdlet in the DSC Resource:
+1. Add any variables that are required to be accessed outside the module by unit
+  tests to the `Export-ModuleMember` cmdlet in the DSC Resource:
 
-```powershell
-Export-ModuleMember -Function *-TargetResource -Variables LocalizedData
-```
+   ```powershell
+   Export-ModuleMember -Function *-TargetResource -Variables LocalizedData
+   ```
 
 ## Creating Mock Output Variables without InModuleScope
 
-One useful pattern used when creating unit tests is to create variables that contain objects that will be returned when mocked cmdlets are called.
-These variables are often used many times over a single unit test file and so assigning each to a variable is essential to reduce the size of the unit test as well as improve readability and maintainability.
+One useful pattern used when creating unit tests is to create variables that
+contain objects that will be returned when mocked cmdlets are called.
+These variables are often used many times over a single unit test file and so
+assigning each to a variable is essential to reduce the size of the unit test as
+well as improve readability and maintainability.
 For example:
 
 ```powershell
@@ -115,8 +153,9 @@ Mock `
     -MockWith { return $MockNetAdapter }
 ```
 
-However, when `InModuleScope` is being used the variables that are defined won't be accessible from within the mocked cmdlets.
-The solution to this is create a script block variable that contains the mocked object and then assign that to the Mock.
+However, when `InModuleScope` is being used the variables that are defined won't
+be accessible from within the mocked cmdlets. The solution to this is create a script
+block variable that contains the mocked object and then assign that to the Mock.
 
 ```powershell
 $GetNetAdapter_PhysicalNetAdapterMock = {
@@ -137,7 +176,8 @@ Mock `
 ## Example Unit Test Patterns
 
 Pattern 1:
-The goal of this pattern should be to describe the potential states a system could be in for each function.
+The goal of this pattern should be to describe the potential states a system could
+be in for each function.
 
 ```powershell
 
@@ -155,59 +195,65 @@ The goal of this pattern should be to describe the potential states a system cou
 ```
 
 Pattern 2:
-The goal of this pattern should be to describe the potential states a system could be in so that the get/set/test cmdlets can be tested in those states. Any mocks that relate to that specific state can be included in the relevant Describe block. For a more detailed description of this approach please review #143
+The goal of this pattern should be to describe the potential states a system
+could be in so that the get/set/test cmdlets can be tested in those states.
+Any mocks that relate to that specific state can be included in the relevant
+Describe block. For a more detailed description of this approach please review #143
 
-Add as many of these example 'states' as required to simulate the scenarios that the DSC resource is designed to work with, below a simple 'is in desired state' and 'is not in desired state' are used, but there may be more complex combinations of factors, depending on how complex your resource is.
+Add as many of these example 'states' as required to simulate the scenarios that
+the DSC resource is designed to work with, below a simple 'is in desired state'
+and 'is not in desired state' are used, but there may be more complex combinations
+of factors, depending on how complex your resource is.
 
 ```powershell
+Describe 'The system is not in the desired state' {
+    #TODO: Mock cmdlets here that represent the system not being in the desired state
 
-        Describe 'The system is not in the desired state' {
-            #TODO: Mock cmdlets here that represent the system not being in the desired state
+    #TODO: Create a set of parameters to test your get/set/test methods in this state
+    $testParameters = @{
+        Property1 = 'value'
+        Property2 = 'value'
+    }
 
-            #TODO: Create a set of parameters to test your get/set/test methods in this state
-            $testParameters = @{
-                Property1 = 'value'
-                Property2 = 'value'
-            }
+    #TODO: Update the assertions below to align with the expected results of this state
+    It 'Should return something' {
+        Get-TargetResource @testParameters | Should -Be 'something'
+    }
 
-            #TODO: Update the assertions below to align with the expected results of this state
-            It 'Should return something' {
-                Get-TargetResource @testParameters | Should -Be 'something'
-            }
+    It 'Should return false' {
+        Test-TargetResource @testParameters | Should -Be $false
+    }
 
-            It 'Should return false' {
-                Test-TargetResource @testParameters | Should -Be $false
-            }
+    It 'Should call Demo-CmdletName' {
+        Set-TargetResource @testParameters
 
-            It 'Should call Demo-CmdletName' {
-                Set-TargetResource @testParameters
+        #TODO: Assert that the appropriate cmdlets were called
+        Assert-MockCalled Demo-CmdletName
+    }
+}
 
-                #TODO: Assert that the appropriate cmdlets were called
-                Assert-MockCalled Demo-CmdletName
-            }
-        }
+Describe 'The system is in the desired state' {
+    #TODO: Mock cmdlets here that represent the system being in the desired state
 
-        Describe 'The system is in the desired state' {
-            #TODO: Mock cmdlets here that represent the system being in the desired state
+    #TODO: Create a set of parameters to test your get/set/test methods in this state
+    $testParameters = @{
+        Property1 = 'value'
+        Property2 = 'value'
+    }
 
-            #TODO: Create a set of parameters to test your get/set/test methods in this state
-            $testParameters = @{
-                Property1 = 'value'
-                Property2 = 'value'
-            }
+    #TODO: Update the assertions below to align with the expected results of this state
+    It 'Should return something' {
+        Get-TargetResource @testParameters | Should -Be 'something'
+    }
 
-            #TODO: Update the assertions below to align with the expected results of this state
-            It 'Should return something' {
-                Get-TargetResource @testParameters | Should -Be 'something'
-            }
-
-            It 'Should return true' {
-                Test-TargetResource @testParameters | Should -Be $true
-            }
-        }
+    It 'Should return true' {
+        Test-TargetResource @testParameters | Should -Be $true
+    }
+}
 ```
 
-To see examples of the Unit/Integration tests in practice, see the NetworkingDsc MSFT_DhcpClient resource:
+To see examples of the Unit/Integration tests in practice, see the NetworkingDsc
+MSFT_DhcpClient resource:
 
 - [Unit Tests](https://github.com/PowerShell/NetworkingDsc/blob/dev/Tests/Unit/MSFT_DhcpClient.Tests.ps1)
 - [Integration Tests](https://github.com/PowerShell/NetworkingDsc/blob/dev/Tests/Integration/MSFT_DhcpClient.Integration.Tests.ps1)


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds markdownlinting settings for VSCode and cleans up *most* of the MD violations (there are still more, but this is 95% cleaned up).

I replaced the Gitter icons with links to PS Slack and Discord badges.

#### This Pull Request (PR) fixes the following issues

- Fixes #512 
- Fixes #513 

#### Task list

- [x] This PR changes documentation

@gaelcolas , @johlju - would you mind reviewing/merging?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/521)
<!-- Reviewable:end -->
