### PR TITLE
Deprecate SystemLocaleDsc

### DIFF
--- a/Maintainers.md
+++ b/Maintainers.md
@@ -60,7 +60,7 @@ and Mariah Breakey ([@mbreakey3](https://github.com/mbreakey3)).
 | [SharePointDsc](https://github.com/PowerShell/SharePointDsc) | Yorick Kuijs ([@ykuijs](https://github.com/YKuijs)) <br/> Nik Charlebois ([@NikCharlebois](https://github.com/NikCharlebois)) |
 | [SqlServerDsc](https://github.com/PowerShell/SqlServerDsc) | Johan Ljunggren ([@johlju](https://github.com/johlju)) |
 | [StorageDsc](https://github.com/PowerShell/StorageDsc) | Daniel Scott-Raynsford ([@PlagueHO](https://github.com/PlagueHO)) |
-| [SystemLocaleDsc](https://github.com/PowerShell/SystemLocaleDsc) | Daniel Scott-Raynsford ([@PlagueHO](https://github.com/PlagueHO)) |
+| [SystemLocaleDsc](https://github.com/PowerShell/SystemLocaleDsc) | DEPRECATED - Migrated to [ComputerManagementDsc](https://github.com/PowerShell/ComputerManagementDsc) |
 | [WmiNamespaceSecurityDsc](https://github.com/PowerShell/WmiNamespaceSecurityDsc) | --- |
 | [WSManDsc](https://github.com/PlagueHO/WSManDsc) | Daniel Scott-Raynsford ([@PlagueHO](https://github.com/PlagueHO)) |
 | [xAzure](https://github.com/PowerShell/xAzure) | Chase Wilson ([@chasewilson](https://github.com/chasewilson)) <br/> Jason Ryberg ([@devopsjesus](https://github.com/devopsjesus)) |


### PR DESCRIPTION
#### Pull Request (PR) description

This PR deprecates SystemLocaleDsc because it has been migrated to ComputerManagementDsc.

#### This Pull Request (PR) fixes the following issues

#### Task list

- [x] This PR changes documentation

This can be merged after this PR is through: https://github.com/PowerShell/ComputerManagementDsc/pull/280

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresources/532)
<!-- Reviewable:end -->
